### PR TITLE
Update property listing forms

### DIFF
--- a/front/src/app/property/my-properties-dialog.component.html
+++ b/front/src/app/property/my-properties-dialog.component.html
@@ -6,12 +6,10 @@
         <tr>
           <th>{{ 'PROPERTY.IMAGE' | translate }}</th>
           <th>{{ 'PROPERTY.STATUS' | translate }}</th>
-          <th>{{ 'PROPERTY.NAME' | translate }}</th>
-          <th>{{ 'PROPERTY.DATE' | translate }}</th>
-          <th>{{ 'PROPERTY.BREED' | translate }}</th>
-          <th>{{ 'PROPERTY.SIZE' | translate }}</th>
-          <th>{{ 'PROPERTY.COLOR' | translate }}</th>
-          <th>{{ 'PROPERTY.OBSERVATION' | translate }}</th>
+          <th>{{ 'PROPERTY.TITLE' | translate }}</th>
+          <th>{{ 'PROPERTY.PRICE' | translate }}</th>
+          <th>{{ 'PROPERTY.BEDROOMS' | translate }}</th>
+          <th>{{ 'PROPERTY.BATHROOMS' | translate }}</th>
           <th>{{ 'PROPERTY.PHONE' | translate }}</th>
           <th>{{ 'PROPERTY.ACTIONS' | translate }}</th>
         </tr>
@@ -22,12 +20,10 @@
             <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
           </td>
           <td>{{ ('PROPERTY.STATUS_' + p.status) | translate }}</td>
-          <td>{{ p.name }}</td>
-          <td>{{ p.date | date:'dd/MM/yyyy' }}</td>
-          <td>{{ p.breed }}</td>
-          <td>{{ p.size }}</td>
-          <td>{{ p.color }}</td>
-          <td>{{ p.observation }}</td>
+          <td>{{ p.title }}</td>
+          <td>{{ p.price }}</td>
+          <td>{{ p.bedrooms }}</td>
+          <td>{{ p.bathrooms }}</td>
           <td>{{ p.phone }}</td>
           <td>
             <button mat-button color="primary" (click)="edit(p)" [disabled]="p.deleted">{{ 'PROPERTY.EDIT' | translate }}</button>

--- a/front/src/app/property/property-detail.component.html
+++ b/front/src/app/property/property-detail.component.html
@@ -4,12 +4,13 @@
     <img *ngFor="let img of property.images" [src]="img" />
   </div>
   <div class="info">
-    <div class="info-item" *ngIf="property.name"><span class="label">{{ 'PROPERTY.NAME' | translate }}:</span> {{ property.name }}</div>
-    <div class="info-item" *ngIf="property.date"><span class="label">{{ 'PROPERTY.DATE' | translate }}:</span> {{ property.date | date:'dd/MM/yyyy' }}</div>
+    <div class="info-item" *ngIf="property.title"><span class="label">{{ 'PROPERTY.TITLE' | translate }}:</span> {{ property.title }}</div>
+    <div class="info-item" *ngIf="property.subtitle"><span class="label">{{ 'PROPERTY.SUBTITLE' | translate }}:</span> {{ property.subtitle }}</div>
     <div class="info-item"><span class="label">{{ 'PROPERTY.STATUS' | translate }}:</span> {{ ('PROPERTY.STATUS_' + property.status) | translate }}</div>
-    <div class="info-item" *ngIf="property.breed"><span class="label">{{ 'PROPERTY.BREED' | translate }}:</span> {{ property.breed }}</div>
-    <div class="info-item" *ngIf="property.size"><span class="label">{{ 'PROPERTY.SIZE' | translate }}:</span> {{ property.size }}</div>
-    <div class="info-item" *ngIf="property.color"><span class="label">{{ 'PROPERTY.COLOR' | translate }}:</span> {{ property.color }}</div>
+    <div class="info-item" *ngIf="property.price"><span class="label">{{ 'PROPERTY.PRICE' | translate }}:</span> {{ property.price | currency }}</div>
+    <div class="info-item" *ngIf="property.bedrooms"><span class="label">{{ 'PROPERTY.BEDROOMS' | translate }}:</span> {{ property.bedrooms }}</div>
+    <div class="info-item" *ngIf="property.bathrooms"><span class="label">{{ 'PROPERTY.BATHROOMS' | translate }}:</span> {{ property.bathrooms }}</div>
+    <div class="info-item" *ngIf="property.areaTotal"><span class="label">{{ 'PROPERTY.AREA_TOTAL' | translate }}:</span> {{ property.areaTotal }}</div>
     <div class="info-item" *ngIf="property.phone"><span class="label">{{ 'PROPERTY.PHONE' | translate }}:</span> {{ property.phone }}</div>
     <div class="info-item" *ngIf="property.observation"><span class="label">{{ 'PROPERTY.OBSERVATION' | translate }}:</span> {{ property.observation }}</div>
   </div>

--- a/front/src/app/property/property-form.component.html
+++ b/front/src/app/property/property-form.component.html
@@ -10,9 +10,95 @@
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>{{ 'PROPERTY.STATUS' | translate }}</mat-label>
         <mat-select formControlName="status">
-          <mat-option value="LOST">{{ 'PROPERTY.STATUS_LOST' | translate }}</mat-option>
-          <mat-option value="FOUND">{{ 'PROPERTY.STATUS_FOUND' | translate }}</mat-option>
+          <mat-option value="SALE">{{ 'PROPERTY.STATUS_LOST' | translate }}</mat-option>
+          <mat-option value="RENT">{{ 'PROPERTY.STATUS_FOUND' | translate }}</mat-option>
         </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.TITLE' | translate }}</mat-label>
+        <input matInput formControlName="title" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.SUBTITLE' | translate }}</mat-label>
+        <input matInput formControlName="subtitle" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.PROPERTY_TYPE' | translate }}</mat-label>
+        <input matInput formControlName="propertyType" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.PRICE' | translate }}</mat-label>
+        <input matInput type="number" formControlName="price" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.CONDO_FEE' | translate }}</mat-label>
+        <input matInput type="number" formControlName="condoFee" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.REFERENCE' | translate }}</mat-label>
+        <input matInput formControlName="reference" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.REALTOR' | translate }}</mat-label>
+        <input matInput formControlName="realtor" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.BEDROOMS' | translate }}</mat-label>
+        <input matInput type="number" formControlName="bedrooms" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.SUITES' | translate }}</mat-label>
+        <input matInput type="number" formControlName="suites" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.BATHROOMS' | translate }}</mat-label>
+        <input matInput type="number" formControlName="bathrooms" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.GARAGES' | translate }}</mat-label>
+        <input matInput type="number" formControlName="garages" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.AREA_UTIL' | translate }}</mat-label>
+        <input matInput type="number" formControlName="areaUtil" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.AREA_TOTAL' | translate }}</mat-label>
+        <input matInput type="number" formControlName="areaTotal" />
+      </mat-form-field>
+    </div>
+    <div class="column">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.DESCRIPTION' | translate }}</mat-label>
+        <textarea matInput formControlName="description"></textarea>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.PROPERTY_ITEMS' | translate }}</mat-label>
+        <textarea matInput formControlName="propertyItems"></textarea>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.BUILDING_ITEMS' | translate }}</mat-label>
+        <textarea matInput formControlName="buildingItems"></textarea>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.NEIGHBORHOOD' | translate }}</mat-label>
+        <input matInput formControlName="neighborhood" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.STREET' | translate }}</mat-label>
+        <input matInput formControlName="street" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.NEIGHBORHOOD_DESCRIPTION' | translate }}</mat-label>
+        <textarea matInput formControlName="neighborhoodDescription"></textarea>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.OBSERVATION' | translate }}</mat-label>
+        <textarea matInput formControlName="observation"></textarea>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PROPERTY.PHONE' | translate }}</mat-label>
+        <input matInput formControlName="phone" mask="(00) 00000-0000" />
       </mat-form-field>
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>{{ 'PROPERTY.NAME' | translate }}</mat-label>
@@ -24,34 +110,9 @@
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>
       </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'PROPERTY.BREED' | translate }}</mat-label>
-        <input matInput formControlName="breed" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'PROPERTY.SIZE' | translate }}</mat-label>
-        <input matInput formControlName="size" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'PROPERTY.COLOR' | translate }}</mat-label>
-        <input matInput formControlName="color" />
-      </mat-form-field>
-    </div>
-    <div class="column">
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'PROPERTY.OBSERVATION' | translate }}</mat-label>
-        <textarea matInput formControlName="observation"></textarea>
-      </mat-form-field>
-
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'PROPERTY.PHONE' | translate }}</mat-label>
-        <input matInput formControlName="phone" mask="(00) 00000-0000" />
-      </mat-form-field>
-
       <label class="address-label">{{ 'PROPERTY.SELECT_ADDRESS' | translate }}</label>
       <div id="selectMap" class="map"></div>
       <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
-
       <label class="images-label">{{ 'PROPERTY.IMAGES' | translate }}</label>
       <input type="file" multiple accept="image/*" (change)="onFile($event)" />
       <div class="preview-list">

--- a/front/src/app/property/property-form.component.ts
+++ b/front/src/app/property/property-form.component.ts
@@ -51,7 +51,7 @@ export class PropertyFormComponent implements OnInit, AfterViewInit {
   private pendingCoords?: L.LatLngTuple;
 
   private getCurrentIcon(): L.Icon {
-    return this.form?.value.status === 'FOUND' ? rentIcon : saleIcon;
+    return this.form?.value.status === 'RENT' ? rentIcon : saleIcon;
   }
 
   id?: number;
@@ -65,14 +65,30 @@ export class PropertyFormComponent implements OnInit, AfterViewInit {
     @Inject(MAT_DIALOG_DATA) @Optional() data?: { id?: number }
   ) {
     this.form = this.fb.group({
-      status: ['LOST', Validators.required],
-      name: ['', Validators.required],
-      date: ['', Validators.required],
-      breed: ['', Validators.required],
-      size: ['', Validators.required],
-      color: ['', Validators.required],
-      observation: ['', Validators.required],
+      status: ['SALE', Validators.required],
+      title: ['', Validators.required],
+      subtitle: [''],
+      propertyType: [''],
+      price: [null],
+      condoFee: [null],
+      reference: [''],
+      realtor: [''],
+      bedrooms: [null],
+      suites: [null],
+      bathrooms: [null],
+      garages: [null],
+      areaUtil: [null],
+      areaTotal: [null],
+      description: [''],
+      propertyItems: [''],
+      buildingItems: [''],
+      neighborhood: [''],
+      street: [''],
+      neighborhoodDescription: [''],
+      observation: [''],
       phone: ['', Validators.required],
+      name: [''],
+      date: [''],
       latitude: [null, Validators.required],
       longitude: [null, Validators.required]
     });
@@ -87,6 +103,12 @@ export class PropertyFormComponent implements OnInit, AfterViewInit {
     if (paramId) {
       this.id = +paramId;
       this.service.get(this.id).subscribe(p => {
+        if(p.propertyItems){
+          (p as any).propertyItems = p.propertyItems.join(', ');
+        }
+        if(p.buildingItems){
+          (p as any).buildingItems = p.buildingItems.join(', ');
+        }
         this.form.patchValue(p);
         if(p.date){
           this.form.patchValue({ date: new Date(p.date) });
@@ -196,6 +218,11 @@ export class PropertyFormComponent implements OnInit, AfterViewInit {
     for(const key in this.form.value){
       let val = (this.form.value as any)[key];
       if(val !== null && val !== undefined){
+        if(key === 'propertyItems' || key === 'buildingItems'){
+          val.split(',').map((v: string) => v.trim()).filter((v: string) => v)
+            .forEach((v: string) => data.append(key, v));
+          continue;
+        }
         if(val instanceof Date){
           val = val.toISOString().split('T')[0];
         }

--- a/front/src/app/property/property-map.component.html
+++ b/front/src/app/property/property-map.component.html
@@ -7,8 +7,8 @@
           <mat-label>{{ 'PROPERTY.FILTER_STATUS' | translate }}</mat-label>
           <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilters()">
             <mat-option value="">{{ 'PROPERTY.ALL' | translate }}</mat-option>
-            <mat-option value="LOST">{{ 'PROPERTY.STATUS_LOST' | translate }}</mat-option>
-            <mat-option value="FOUND">{{ 'PROPERTY.STATUS_FOUND' | translate }}</mat-option>
+            <mat-option value="SALE">{{ 'PROPERTY.STATUS_LOST' | translate }}</mat-option>
+            <mat-option value="RENT">{{ 'PROPERTY.STATUS_FOUND' | translate }}</mat-option>
           </mat-select>
         </mat-form-field>
 

--- a/front/src/app/property/property-map.component.ts
+++ b/front/src/app/property/property-map.component.ts
@@ -150,7 +150,7 @@ export class PropertyMapComponent implements OnInit {
         this.clusterLayer.addLayer(marker);
       } else {
         const property = (c.properties as any).property as PropertyListing;
-        const icon = property.status === 'FOUND' ? rentIcon : saleIcon;
+        const icon = property.status === 'RENT' ? rentIcon : saleIcon;
         const marker = L.marker([lat, lng], { icon });
         const popupHost = document.createElement('div');
         const compRef = this.vcr.createComponent(PropertyPopupComponent, {

--- a/front/src/app/property/property-popup.component.html
+++ b/front/src/app/property/property-popup.component.html
@@ -1,12 +1,11 @@
 <div class="popup-card">
   <img *ngIf="property.images?.length" [src]="property.images?.[0]" class="popup-img" />
   <div class="popup-info-card">
-    <div class="info-item" *ngIf="property.name"><span class="label">{{ 'PROPERTY.NAME' | translate }}:</span> {{ property.name }}</div>
-    <div class="info-item" *ngIf="property.date"><span class="label">{{ 'PROPERTY.DATE' | translate }}:</span> {{ property.date | date:'dd/MM/yyyy' }}</div>
+    <div class="info-item" *ngIf="property.title"><span class="label">{{ 'PROPERTY.TITLE' | translate }}:</span> {{ property.title }}</div>
+    <div class="info-item" *ngIf="property.price"><span class="label">{{ 'PROPERTY.PRICE' | translate }}:</span> {{ property.price | currency }}</div>
     <div class="info-item"><span class="label">{{ 'PROPERTY.STATUS' | translate }}:</span> {{ ('PROPERTY.STATUS_' + property.status) | translate }}</div>
-    <div class="info-item" *ngIf="property.breed"><span class="label">{{ 'PROPERTY.BREED' | translate }}:</span> {{ property.breed }}</div>
-    <div class="info-item" *ngIf="property.size"><span class="label">{{ 'PROPERTY.SIZE' | translate }}:</span> {{ property.size }}</div>
-    <div class="info-item" *ngIf="property.color"><span class="label">{{ 'PROPERTY.COLOR' | translate }}:</span> {{ property.color }}</div>
+    <div class="info-item" *ngIf="property.bedrooms"><span class="label">{{ 'PROPERTY.BEDROOMS' | translate }}:</span> {{ property.bedrooms }}</div>
+    <div class="info-item" *ngIf="property.bathrooms"><span class="label">{{ 'PROPERTY.BATHROOMS' | translate }}:</span> {{ property.bathrooms }}</div>
     <div class="info-item" *ngIf="property.phone">
       <span class="label">{{ 'PROPERTY.PHONE' | translate }}:</span> {{ property.phone }}
       <a class="whatsapp-link" [href]="'https://wa.me/' + phoneDigits(property.phone)" target="_blank">

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -142,7 +142,26 @@
         "LAST_15_DAYS": "Last 15 days",
         "LAST_30_DAYS": "Last 30 days",
         "ALL": "All",
-        "MORE_DETAILS": "More details"
+        "MORE_DETAILS": "More details",
+        "TITLE": "Title",
+        "SUBTITLE": "Subtitle",
+        "PROPERTY_TYPE": "Type",
+        "PRICE": "Price",
+        "CONDO_FEE": "Condo fee",
+        "REFERENCE": "Reference",
+        "REALTOR": "Realtor",
+        "BEDROOMS": "Bedrooms",
+        "SUITES": "Suites",
+        "BATHROOMS": "Bathrooms",
+        "GARAGES": "Garages",
+        "AREA_UTIL": "Usable area",
+        "AREA_TOTAL": "Total area",
+        "DESCRIPTION": "Description",
+        "PROPERTY_ITEMS": "Property items (comma separated)",
+        "BUILDING_ITEMS": "Building items (comma separated)",
+        "NEIGHBORHOOD": "Neighborhood",
+        "STREET": "Street",
+        "NEIGHBORHOOD_DESCRIPTION": "Neighborhood description"
       },
       "FOOTER": {
         "BY": "by jpfurlan"

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -149,7 +149,26 @@
       "LAST_15_DAYS": "Últimos 15 dias",
       "LAST_30_DAYS": "Últimos 30 dias",
       "ALL": "Todos",
-      "MORE_DETAILS": "Mais detalhes"
+      "MORE_DETAILS": "Mais detalhes",
+      "TITLE": "Título",
+      "SUBTITLE": "Subtítulo",
+      "PROPERTY_TYPE": "Tipo",
+      "PRICE": "Preço",
+      "CONDO_FEE": "Condomínio",
+      "REFERENCE": "Referência",
+      "REALTOR": "Corretor",
+      "BEDROOMS": "Quartos",
+      "SUITES": "Suítes",
+      "BATHROOMS": "Banheiros",
+      "GARAGES": "Garagens",
+      "AREA_UTIL": "Área útil",
+      "AREA_TOTAL": "Área total",
+      "DESCRIPTION": "Descrição",
+      "PROPERTY_ITEMS": "Itens do imóvel (separados por vírgula)",
+      "BUILDING_ITEMS": "Itens do prédio (separados por vírgula)",
+      "NEIGHBORHOOD": "Bairro",
+      "STREET": "Rua",
+      "NEIGHBORHOOD_DESCRIPTION": "Descrição do bairro"
     },
     "FOOTER": {
       "BY": "by jpfurlan"


### PR DESCRIPTION
## Summary
- implement property listing form with backend fields
- adjust property popups, detail page, list dialogs and map filters
- update i18n with new property field labels

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685734e37260832981d7418e18abeb83