### PR TITLE
Improve property detail view

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/property/PropertyListingService.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/property/PropertyListingService.java
@@ -22,9 +22,8 @@ public class PropertyListingService {
     public PropertyListing save(PropertyListing listing, MultipartFile[] files, User user) throws IOException {
         List<String> paths = new ArrayList<>();
         if(files != null){
-            int count = Math.min(files.length,3);
-            for(int i=0;i<count;i++){
-                paths.add(imageService.resizeAndSave(files[i]));
+            for(MultipartFile file : files){
+                paths.add(imageService.resizeAndSave(file));
             }
         }
         listing.setImages(paths);
@@ -81,10 +80,9 @@ public class PropertyListingService {
         existing.setLongitude(data.getLongitude());
 
         if(files != null && files.length > 0){
-            List<String> paths = new ArrayList<>();
-            int count = Math.min(files.length,3);
-            for(int i=0;i<count;i++){
-                paths.add(imageService.resizeAndSave(files[i]));
+            List<String> paths = new ArrayList<>(existing.getImages());
+            for(MultipartFile file : files){
+                paths.add(imageService.resizeAndSave(file));
             }
             existing.setImages(paths);
         }

--- a/front/src/app/property/property-detail.component.html
+++ b/front/src/app/property/property-detail.component.html
@@ -1,19 +1,41 @@
 <div class="property-detail" *ngIf="property">
   <button mat-button routerLink="/property" class="back-btn">{{ 'COMMON.BACK' | translate }}</button>
-  <div class="images" *ngIf="property.images?.length">
-    <img *ngFor="let img of property.images" [src]="img" />
+  <div class="images" *ngIf="displayImages.length">
+    <img *ngFor="let img of displayImages" [src]="img" />
+  </div>
+  <div class="extra-carousel" *ngIf="extraImages.length">
+    <div class="carousel">
+      <button mat-icon-button type="button" (click)="prevImage()"><mat-icon>chevron_left</mat-icon></button>
+      <img [src]="extraImages[currentImage]" />
+      <button mat-icon-button type="button" (click)="nextImage()"><mat-icon>chevron_right</mat-icon></button>
+    </div>
   </div>
   <div class="info">
     <div class="info-item" *ngIf="property.title"><span class="label">{{ 'PROPERTY.TITLE' | translate }}:</span> {{ property.title }}</div>
     <div class="info-item" *ngIf="property.subtitle"><span class="label">{{ 'PROPERTY.SUBTITLE' | translate }}:</span> {{ property.subtitle }}</div>
+    <div class="info-item" *ngIf="property.propertyType"><span class="label">Tipo:</span> {{ property.propertyType }}</div>
     <div class="info-item" *ngIf="property.propertySubtype"><span class="label">Subtipo:</span> {{ property.propertySubtype | enumLabel }}</div>
     <div class="info-item" *ngIf="property.finalidade"><span class="label">Finalidade:</span> {{ property.finalidade }}</div>
     <div class="info-item"><span class="label">{{ 'PROPERTY.STATUS' | translate }}:</span> {{ ('PROPERTY.STATUS_' + property.status) | translate }}</div>
     <div class="info-item" *ngIf="property.price"><span class="label">{{ 'PROPERTY.PRICE' | translate }}:</span> {{ property.price | currency }}</div>
+    <div class="info-item" *ngIf="property.condoFee"><span class="label">{{ 'PROPERTY.CONDO_FEE' | translate }}:</span> {{ property.condoFee }}</div>
+    <div class="info-item" *ngIf="property.reference"><span class="label">{{ 'PROPERTY.REFERENCE' | translate }}:</span> {{ property.reference }}</div>
+    <div class="info-item" *ngIf="property.realtor"><span class="label">{{ 'PROPERTY.REALTOR' | translate }}:</span> {{ property.realtor }}</div>
     <div class="info-item" *ngIf="property.bedrooms"><span class="label">{{ 'PROPERTY.BEDROOMS' | translate }}:</span> {{ property.bedrooms }}</div>
+    <div class="info-item" *ngIf="property.suites"><span class="label">{{ 'PROPERTY.SUITES' | translate }}:</span> {{ property.suites }}</div>
     <div class="info-item" *ngIf="property.bathrooms"><span class="label">{{ 'PROPERTY.BATHROOMS' | translate }}:</span> {{ property.bathrooms }}</div>
+    <div class="info-item" *ngIf="property.garages"><span class="label">{{ 'PROPERTY.GARAGES' | translate }}:</span> {{ property.garages }}</div>
+    <div class="info-item" *ngIf="property.areaUtil"><span class="label">{{ 'PROPERTY.AREA_UTIL' | translate }}:</span> {{ property.areaUtil }}</div>
     <div class="info-item" *ngIf="property.areaTotal"><span class="label">{{ 'PROPERTY.AREA_TOTAL' | translate }}:</span> {{ property.areaTotal }}</div>
+    <div class="info-item" *ngIf="property.description"><span class="label">{{ 'PROPERTY.DESCRIPTION' | translate }}:</span> {{ property.description }}</div>
+    <div class="info-item" *ngIf="property.propertyItems?.length"><span class="label">{{ 'PROPERTY.PROPERTY_ITEMS' | translate }}:</span> {{ property.propertyItems.map(i => (i | enumLabel)).join(', ') }}</div>
+    <div class="info-item" *ngIf="property.buildingItems?.length"><span class="label">{{ 'PROPERTY.BUILDING_ITEMS' | translate }}:</span> {{ property.buildingItems.map(i => (i | enumLabel)).join(', ') }}</div>
+    <div class="info-item" *ngIf="property.neighborhood"><span class="label">{{ 'PROPERTY.NEIGHBORHOOD' | translate }}:</span> {{ property.neighborhood }}</div>
+    <div class="info-item" *ngIf="property.street"><span class="label">{{ 'PROPERTY.STREET' | translate }}:</span> {{ property.street }}</div>
+    <div class="info-item" *ngIf="property.neighborhoodDescription"><span class="label">{{ 'PROPERTY.NEIGHBORHOOD_DESCRIPTION' | translate }}:</span> {{ property.neighborhoodDescription }}</div>
     <div class="info-item" *ngIf="property.phone"><span class="label">{{ 'PROPERTY.PHONE' | translate }}:</span> {{ property.phone }}</div>
     <div class="info-item" *ngIf="property.observation"><span class="label">{{ 'PROPERTY.OBSERVATION' | translate }}:</span> {{ property.observation }}</div>
+    <div class="info-item" *ngIf="property.name"><span class="label">{{ 'PROPERTY.NAME' | translate }}:</span> {{ property.name }}</div>
+    <div class="info-item" *ngIf="property.date"><span class="label">{{ 'PROPERTY.DATE' | translate }}:</span> {{ property.date }}</div>
   </div>
 </div>

--- a/front/src/app/property/property-detail.component.scss
+++ b/front/src/app/property/property-detail.component.scss
@@ -5,16 +5,32 @@
 }
 
 .images {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
-  flex-wrap: wrap;
   margin-bottom: 8px;
 
   img {
-    width: 200px;
-    height: 260px;
+    width: 100%;
+    height: 200px;
     object-fit: cover;
     border-radius: 4px;
+  }
+}
+
+.extra-carousel {
+  margin-bottom: 8px;
+
+  .carousel {
+    display: flex;
+    align-items: center;
+
+    img {
+      width: 200px;
+      height: 260px;
+      object-fit: cover;
+      border-radius: 4px;
+    }
   }
 }
 

--- a/front/src/app/property/property-detail.component.ts
+++ b/front/src/app/property/property-detail.component.ts
@@ -15,13 +15,34 @@ import { EnumLabelPipe } from './enum-label.pipe';
 })
 export class PropertyDetailComponent implements OnInit {
   property?: PropertyListing;
+  displayImages: string[] = [];
+  extraImages: string[] = [];
+  currentImage = 0;
 
   constructor(private service: PropertyService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
     if (id) {
-      this.service.get(id).subscribe(p => (this.property = p));
+      this.service.get(id).subscribe(p => {
+        this.property = p;
+        if (p.images) {
+          this.displayImages = p.images.slice(0, 6);
+          this.extraImages = p.images.slice(6);
+        }
+      });
+    }
+  }
+
+  nextImage() {
+    if (this.extraImages.length) {
+      this.currentImage = (this.currentImage + 1) % this.extraImages.length;
+    }
+  }
+
+  prevImage() {
+    if (this.extraImages.length) {
+      this.currentImage = (this.currentImage - 1 + this.extraImages.length) % this.extraImages.length;
     }
   }
 }

--- a/front/src/app/property/property-form.component.ts
+++ b/front/src/app/property/property-form.component.ts
@@ -212,8 +212,7 @@ export class PropertyFormComponent implements OnInit, AfterViewInit {
     const files: FileList = event.target.files;
     this.imageLoading = true;
     this.images = Array.from(files)
-      .filter(f => f.type.startsWith('image/'))
-      .slice(0, 3);
+      .filter(f => f.type.startsWith('image/'));
     this.imageUrls = [...this.existingImages];
     let remaining = this.images.length;
     if (remaining === 0) {


### PR DESCRIPTION
## Summary
- show more images on property detail and add carousel for extras
- display all property fields on the detail page
- allow uploading multiple images without limit
- append new images to existing ones when updating properties

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857eac194a083298320d15eed8349b2