### PR TITLE
Fix property detail template bindings

### DIFF
--- a/front/src/app/property/property-detail.component.html
+++ b/front/src/app/property/property-detail.component.html
@@ -28,8 +28,8 @@
     <div class="info-item" *ngIf="property.areaUtil"><span class="label">{{ 'PROPERTY.AREA_UTIL' | translate }}:</span> {{ property.areaUtil }}</div>
     <div class="info-item" *ngIf="property.areaTotal"><span class="label">{{ 'PROPERTY.AREA_TOTAL' | translate }}:</span> {{ property.areaTotal }}</div>
     <div class="info-item" *ngIf="property.description"><span class="label">{{ 'PROPERTY.DESCRIPTION' | translate }}:</span> {{ property.description }}</div>
-    <div class="info-item" *ngIf="property.propertyItems?.length"><span class="label">{{ 'PROPERTY.PROPERTY_ITEMS' | translate }}:</span> {{ property.propertyItems.map(i => (i | enumLabel)).join(', ') }}</div>
-    <div class="info-item" *ngIf="property.buildingItems?.length"><span class="label">{{ 'PROPERTY.BUILDING_ITEMS' | translate }}:</span> {{ property.buildingItems.map(i => (i | enumLabel)).join(', ') }}</div>
+    <div class="info-item" *ngIf="property.propertyItems?.length"><span class="label">{{ 'PROPERTY.PROPERTY_ITEMS' | translate }}:</span> {{ getEnumLabels(property.propertyItems) }}</div>
+    <div class="info-item" *ngIf="property.buildingItems?.length"><span class="label">{{ 'PROPERTY.BUILDING_ITEMS' | translate }}:</span> {{ getEnumLabels(property.buildingItems) }}</div>
     <div class="info-item" *ngIf="property.neighborhood"><span class="label">{{ 'PROPERTY.NEIGHBORHOOD' | translate }}:</span> {{ property.neighborhood }}</div>
     <div class="info-item" *ngIf="property.street"><span class="label">{{ 'PROPERTY.STREET' | translate }}:</span> {{ property.street }}</div>
     <div class="info-item" *ngIf="property.neighborhoodDescription"><span class="label">{{ 'PROPERTY.NEIGHBORHOOD_DESCRIPTION' | translate }}:</span> {{ property.neighborhoodDescription }}</div>

--- a/front/src/app/property/property-detail.component.ts
+++ b/front/src/app/property/property-detail.component.ts
@@ -18,6 +18,11 @@ export class PropertyDetailComponent implements OnInit {
   displayImages: string[] = [];
   extraImages: string[] = [];
   currentImage = 0;
+  private enumPipe = new EnumLabelPipe();
+
+  getEnumLabels(items?: string[]): string {
+    return items?.map(i => this.enumPipe.transform(i)).join(', ') || '';
+  }
 
   constructor(private service: PropertyService, private route: ActivatedRoute) {}
 


### PR DESCRIPTION
## Summary
- add helper method to map enum labels
- use method in property detail template to avoid arrow functions

## Testing
- `npm ci`
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecd9c318832984933c543901e006