### PR TITLE
Fix MatIcon usage in detail component

### DIFF
--- a/front/src/app/property/property-detail.component.ts
+++ b/front/src/app/property/property-detail.component.ts
@@ -4,12 +4,20 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import { PropertyService, PropertyListing } from './property.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { EnumLabelPipe } from './enum-label.pipe';
 
 @Component({
   selector: 'app-property-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule, EnumLabelPipe],
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    TranslateModule,
+    EnumLabelPipe
+  ],
   templateUrl: './property-detail.component.html',
   styleUrls: ['./property-detail.component.scss']
 })


### PR DESCRIPTION
## Summary
- add missing MatIconModule import for property detail component

## Testing
- `npx ng build` *(fails: bundle initial exceeded maximum budget)*
- `npx ng test --watch=false` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee223ed48329851121fc3cf5f250