### PR TITLE
Implement fair management UI and update security

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -66,6 +66,7 @@ public class SecurityConfiguration {
                   .csrf(AbstractHttpConfigurer::disable)
                   .authorizeHttpRequests(auth -> auth
                           .requestMatchers(mvc.pattern("/api/v1/auth/**")).permitAll()
+                          .requestMatchers(HttpMethod.GET, "/api/v1/fair/**").permitAll()
                           .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                           .requestMatchers(SWAGGER_WHITELIST).permitAll()
                           .anyRequest().authenticated())

--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { RecoveryComponent } from './auth/recovery/recovery.component';
 import { ResetPasswordComponent } from './auth/reset-password/reset-password.component';
 import { FairMapComponent } from './fair/fair-map.component';
 import { FairFormComponent } from './fair/fair-form.component';
+import { FairListComponent } from './fair/fair-list.component';
 import { AuthGuard } from './core/auth.guard';
 
 export const routes: Routes = [
@@ -18,5 +19,6 @@ export const routes: Routes = [
   { path: 'fair', component: FairMapComponent },
   { path: 'fair/new', component: FairFormComponent, canActivate: [AuthGuard] },
   { path: 'fair/:id/edit', component: FairFormComponent, canActivate: [AuthGuard] },
+  { path: 'fair/manage', component: FairListComponent, canActivate: [AuthGuard] },
   { path: '**', redirectTo: 'login' }
 ];

--- a/front/src/app/fair/fair-list.component.html
+++ b/front/src/app/fair/fair-list.component.html
@@ -1,0 +1,42 @@
+<div class="fair-list">
+  <div class="actions">
+    <mat-form-field appearance="outline">
+      <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>
+      <mat-select [(ngModel)]="day" (selectionChange)="applyFilter()">
+        <mat-option *ngFor="let d of daysOfWeek" [value]="d.value">
+          {{ d.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-raised-button color="primary" routerLink="/fair/new">
+      {{ 'FAIR.ADD' | translate }}
+    </button>
+  </div>
+
+  <table mat-table [dataSource]="filtered" class="fair-table" *ngIf="filtered.length">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.NAME' | translate }}</th>
+      <td mat-cell *matCellDef="let f">{{ f.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="schedule">
+      <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.SCHEDULE' | translate }}</th>
+      <td mat-cell *matCellDef="let f">{{ f.schedule }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.ACTIONS' | translate }}</th>
+      <td mat-cell *matCellDef="let f">
+        <button mat-icon-button color="primary" [routerLink]="'/fair/' + f.id + '/edit'">
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button mat-icon-button color="warn" (click)="delete(f.id!)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="['name', 'schedule', 'actions']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['name', 'schedule', 'actions'];"></tr>
+  </table>
+
+  <p *ngIf="!filtered.length">{{ 'NO_FAIRS' | translate }}</p>
+</div>

--- a/front/src/app/fair/fair-list.component.scss
+++ b/front/src/app/fair/fair-list.component.scss
@@ -1,0 +1,10 @@
+.fair-list {
+  padding: 1rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}

--- a/front/src/app/fair/fair-list.component.ts
+++ b/front/src/app/fair/fair-list.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { TranslateModule } from '@ngx-translate/core';
+import { FairService, Fair } from './fair.service';
+
+@Component({
+  selector: 'app-fair-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    TranslateModule
+  ],
+  templateUrl: './fair-list.component.html',
+  styleUrls: ['./fair-list.component.scss']
+})
+export class FairListComponent implements OnInit {
+  fairs: Fair[] = [];
+  filtered: Fair[] = [];
+  day = '';
+
+  daysOfWeek = [
+    { value: '', label: 'Todos' },
+    { value: 'Domingo', label: 'Domingo' },
+    { value: 'Segunda', label: 'Segunda-feira' },
+    { value: 'Terça', label: 'Terça-feira' },
+    { value: 'Quarta', label: 'Quarta-feira' },
+    { value: 'Quinta', label: 'Quinta-feira' },
+    { value: 'Sexta', label: 'Sexta-feira' },
+    { value: 'Sábado', label: 'Sábado' }
+  ];
+
+  constructor(private service: FairService) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.service.myList().subscribe(list => {
+      this.fairs = list;
+      this.applyFilter();
+    });
+  }
+
+  applyFilter() {
+    if (!this.day) {
+      this.filtered = this.fairs;
+    } else {
+      const d = this.day.toLowerCase();
+      this.filtered = this.fairs.filter(f => f.schedule?.toLowerCase().includes(d));
+    }
+  }
+
+  delete(id: number) {
+    this.service.delete(id).subscribe(() => this.load());
+  }
+}

--- a/front/src/app/shared/header/header.component.html
+++ b/front/src/app/shared/header/header.component.html
@@ -4,6 +4,7 @@
   <div class="right-actions">
     <button mat-button (click)="openHowToUse()">{{ 'HOW_TO_USE.TITLE' | translate }}</button>
     <button mat-button (click)="openContribute()">{{ 'CONTRIBUTE.TITLE' | translate }}</button>
+    <a *ngIf="loggedIn" mat-button routerLink="/fair/manage">{{ 'MANAGE_FAIRS' | translate }}</a>
     <a *ngIf="!loggedIn" mat-button routerLink="/login" class="login-button">{{ 'LOGIN.TITLE' | translate }}</a>
     <button *ngIf="loggedIn" mat-button (click)="logout()">Logout</button>
     <div class="lang-menu">

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -101,8 +101,11 @@
         "ACTIONS": "Actions",
         "EDIT": "Edit",
         "REMOVE": "Remove",
-        "SAVE": "Save"
+      "SAVE": "Save"
       },
+      "MANAGE_FAIRS": "Manage fairs",
+      "NO_FAIRS": "No fairs found",
+      "FILTER_DAY": "Filter by day",
       "FOOTER": {
         "BY": "by jpfurlan"
       },

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -110,6 +110,9 @@
       "REMOVE": "Remover",
       "SAVE": "Salvar"
     },
+    "MANAGE_FAIRS": "Gerenciar feiras",
+    "NO_FAIRS": "Nenhuma feira cadastrada",
+    "FILTER_DAY": "Filtrar por dia",
     "FOOTER": {
       "BY": "by jpfurlan"
     },

--- a/front/src/index.html
+++ b/front/src/index.html
@@ -11,5 +11,8 @@
 </head>
 <body class="mat-typography">
   <app-root></app-root>
+  <footer class="credits">
+    <a href="https://jpfurlan.dev/" target="_blank" rel="noopener noreferrer">© 2025 jpfurlan.dev</a>
+  </footer>
 </body>
 </html>

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -36,3 +36,20 @@ input[type="password"] {
   width: 30px;
   height: 30px;
 }
+
+footer.credits {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 0;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background: #000;
+  color: #fff;
+}
+
+footer.credits a {
+  color: #fff;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- allow public GET for `/api/v1/fair/**`
- add global credits footer
- style credits footer
- add fair list component with filter and delete functionality
- expose fair management route and link from header
- translate new strings for fair management

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `mvn test` *(fails: mvn command not found earlier; after installation, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6868ff803f248329aeb563901c029457