### PR TITLE
Fix map popup load and add i18n

### DIFF
--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -55,14 +55,25 @@ export class FairMapComponent implements OnInit {
     this.fairs.forEach(f => {
       if (f.latitude && f.longitude) {
         const marker = L.marker([f.latitude, f.longitude]).addTo(this.map!);
-        const popupHost = document.createElement('div');
-        const compRef = this.vcr.createComponent(FairPopupComponent, {
-          environmentInjector: this.injector
+        let compRef: any;
+        marker.on('click', () => {
+          if (compRef) {
+            compRef.destroy();
+          }
+          const popupHost = document.createElement('div');
+          compRef = this.vcr.createComponent(FairPopupComponent, {
+            environmentInjector: this.injector
+          });
+          compRef.instance.fair = f;
+          popupHost.appendChild(compRef.location.nativeElement);
+          marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 260 }).openPopup();
         });
-        compRef.instance.fair = f;
-        popupHost.appendChild(compRef.location.nativeElement);
-        marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 260 });
-        marker.on('popupclose', () => compRef.destroy());
+        marker.on('popupclose', () => {
+          if (compRef) {
+            compRef.destroy();
+            compRef = null;
+          }
+        });
       }
     });
   }

--- a/front/src/app/fair/fair-popup.component.html
+++ b/front/src/app/fair/fair-popup.component.html
@@ -1,11 +1,11 @@
 <div class="popup-card">
   <img *ngIf="fair.imagePath" [src]="fair.imagePath" class="popup-image" />
   <div class="popup-info-card">
-    <div class="info-item"><span class="label">Nome:</span> {{ fair.name }}</div>
-    <div class="info-item" *ngIf="fair.address"><span class="label">Endereço:</span> {{ fair.address }}</div>
-    <div class="info-item" *ngIf="fair.schedule"><span class="label">Horário:</span> {{ fair.schedule }}</div>
-    <div class="info-item" *ngIf="fair.responsible"><span class="label">Responsável:</span> {{ fair.responsible }}</div>
-    <div class="info-item" *ngIf="fair.phone"><span class="label">Telefone:</span> {{ fair.phone }}</div>
-    <div class="info-item" *ngIf="fair.description"><span class="label">Descrição:</span> {{ fair.description }}</div>
+    <div class="info-item"><span class="label">{{ 'FAIR.NAME' | translate }}:</span> {{ fair.name }}</div>
+    <div class="info-item" *ngIf="fair.address"><span class="label">{{ 'FAIR.ADDRESS' | translate }}:</span> {{ fair.address }}</div>
+    <div class="info-item" *ngIf="fair.schedule"><span class="label">{{ 'FAIR.SCHEDULE' | translate }}:</span> {{ fair.schedule }}</div>
+    <div class="info-item" *ngIf="fair.responsible"><span class="label">{{ 'FAIR.RESPONSIBLE' | translate }}:</span> {{ fair.responsible }}</div>
+    <div class="info-item" *ngIf="fair.phone"><span class="label">{{ 'FAIR.PHONE' | translate }}:</span> {{ fair.phone }}</div>
+    <div class="info-item" *ngIf="fair.description"><span class="label">{{ 'FAIR.DESCRIPTION' | translate }}:</span> {{ fair.description }}</div>
   </div>
 </div>

--- a/front/src/app/fair/fair-popup.component.scss
+++ b/front/src/app/fair/fair-popup.component.scss
@@ -8,7 +8,8 @@
 
 .popup-image {
   width: 100%;
-  max-height: 160px;
-  object-fit: cover;
+  height: auto;
+  max-height: 200px;
+  object-fit: contain;
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary
- make popup info labels translatable
- prevent popup info from only loading the first click
- adjust popup image size so it fits nicely

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869485beca083299e2baaa46894f4a8