### PR TITLE
Add attraction entity and fair details page

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/controller/attraction/AttractionController.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/controller/attraction/AttractionController.java
@@ -1,0 +1,51 @@
+package com.securitygateway.loginboilerplate.controller.attraction;
+
+import com.securitygateway.loginboilerplate.model.fair.Attraction;
+import com.securitygateway.loginboilerplate.model.fair.Fair;
+import com.securitygateway.loginboilerplate.repository.attraction.AttractionRepository;
+import com.securitygateway.loginboilerplate.service.fair.FairService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/attractions")
+@RequiredArgsConstructor
+public class AttractionController {
+
+    private final AttractionRepository repository;
+    private final FairService fairService;
+
+    @GetMapping("/fair/{fairId}")
+    public List<Attraction> listByFair(@PathVariable Long fairId) {
+        return repository.findByFairId(fairId);
+    }
+
+    @PostMapping("/fair/{fairId}")
+    public Attraction create(@PathVariable Long fairId, @RequestBody Attraction attraction) {
+        Fair fair = fairService.findById(fairId);
+        attraction.setId(null);
+        attraction.setFair(fair);
+        return repository.save(attraction);
+    }
+
+    @GetMapping("/{id}")
+    public Attraction get(@PathVariable Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    @PutMapping("/{id}")
+    public Attraction update(@PathVariable Long id, @RequestBody Attraction data) {
+        Attraction existing = repository.findById(id).orElseThrow();
+        existing.setName(data.getName());
+        existing.setSpecialty(data.getSpecialty());
+        existing.setSocialMedia(data.getSocialMedia());
+        return repository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Attraction.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Attraction.java
@@ -1,0 +1,30 @@
+package com.securitygateway.loginboilerplate.model.fair;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "attractions")
+public class Attraction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "attraction_seq")
+    @SequenceGenerator(name = "attraction_seq", sequenceName = "attraction_sequence", allocationSize = 1)
+    private Long id;
+
+    private String name;
+    private String specialty;
+    private String socialMedia;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fair_id")
+    @JsonIgnore
+    private Fair fair;
+}

--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
@@ -2,6 +2,8 @@ package com.securitygateway.loginboilerplate.model.fair;
 
 import com.securitygateway.loginboilerplate.model.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.securitygateway.loginboilerplate.model.fair.Attraction;
+import java.util.List;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,6 +35,9 @@ public class Fair {
     private String responsible;
     private String phone;
     private String imagePath;
+
+    @OneToMany(mappedBy = "fair", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Attraction> attractionList;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/back/src/main/java/com/securitygateway/loginboilerplate/repository/attraction/AttractionRepository.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/repository/attraction/AttractionRepository.java
@@ -1,0 +1,10 @@
+package com.securitygateway.loginboilerplate.repository.attraction;
+
+import com.securitygateway.loginboilerplate.model.fair.Attraction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AttractionRepository extends JpaRepository<Attraction, Long> {
+    List<Attraction> findByFairId(Long fairId);
+}

--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { ResetPasswordComponent } from './auth/reset-password/reset-password.com
 import { FairMapComponent } from './fair/fair-map.component';
 import { FairFormComponent } from './fair/fair-form.component';
 import { FairListComponent } from './fair/fair-list.component';
+import { FairDetailComponent } from './fair/fair-detail.component';
 import { AuthGuard } from './core/auth.guard';
 
 export const routes: Routes = [
@@ -19,6 +20,7 @@ export const routes: Routes = [
   { path: 'fair', component: FairMapComponent },
   { path: 'fair/new', component: FairFormComponent, canActivate: [AuthGuard] },
   { path: 'fair/:id/edit', component: FairFormComponent, canActivate: [AuthGuard] },
+  { path: 'fair/:id', component: FairDetailComponent },
   { path: 'fair/manage', component: FairListComponent, canActivate: [AuthGuard] },
   { path: '**', redirectTo: 'login' }
 ];

--- a/front/src/app/fair/attraction.service.ts
+++ b/front/src/app/fair/attraction.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environmet/environment';
+
+export interface Attraction {
+  id?: number;
+  name: string;
+  specialty?: string;
+  socialMedia?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AttractionService {
+  private api = environment.apiUrl + '/attractions';
+
+  constructor(private http: HttpClient) {}
+
+  listByFair(fairId: number): Observable<Attraction[]> {
+    return this.http.get<Attraction[]>(`${this.api}/fair/${fairId}`);
+  }
+
+  create(fairId: number, data: Attraction): Observable<Attraction> {
+    return this.http.post<Attraction>(`${this.api}/fair/${fairId}`, data);
+  }
+
+  update(id: number, data: Attraction): Observable<Attraction> {
+    return this.http.put<Attraction>(`${this.api}/${id}`, data);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.api}/${id}`);
+  }
+
+  get(id: number): Observable<Attraction> {
+    return this.http.get<Attraction>(`${this.api}/${id}`);
+  }
+}

--- a/front/src/app/fair/fair-detail.component.html
+++ b/front/src/app/fair/fair-detail.component.html
@@ -1,0 +1,21 @@
+<div class="fair-detail" *ngIf="fair">
+  <button mat-button routerLink="/fair">&lt; {{ 'COMMON.CLOSE' | translate }}</button>
+  <h2>{{ fair.name }}</h2>
+  <img *ngIf="fair.imagePath" [src]="fair.imagePath" class="detail-image" />
+  <div class="detail-info">
+    <div *ngIf="fair.address"><strong>{{ 'FAIR.ADDRESS' | translate }}:</strong> {{ fair.address }}</div>
+    <div *ngIf="fair.schedule"><strong>{{ 'FAIR.SCHEDULE' | translate }}:</strong> {{ fair.schedule }}</div>
+    <div *ngIf="fair.responsible"><strong>{{ 'FAIR.RESPONSIBLE' | translate }}:</strong> {{ fair.responsible }}</div>
+    <div *ngIf="fair.phone"><strong>{{ 'FAIR.PHONE' | translate }}:</strong> {{ fair.phone }}</div>
+    <div *ngIf="fair.description"><strong>{{ 'FAIR.DESCRIPTION' | translate }}:</strong> {{ fair.description }}</div>
+  </div>
+  <div class="attractions" *ngIf="attractions.length">
+    <h3>{{ 'FAIR.ATTRACTIONS' | translate }}</h3>
+    <ul>
+      <li *ngFor="let a of attractions">
+        {{ a.name }} - {{ a.specialty }}
+        <a *ngIf="a.socialMedia" [href]="a.socialMedia" target="_blank">{{ a.socialMedia }}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/front/src/app/fair/fair-detail.component.scss
+++ b/front/src/app/fair/fair-detail.component.scss
@@ -1,0 +1,8 @@
+.fair-detail {
+  padding: 16px;
+}
+.detail-image {
+  width: 100%;
+  max-width: 400px;
+  margin: 16px 0;
+}

--- a/front/src/app/fair/fair-detail.component.ts
+++ b/front/src/app/fair/fair-detail.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatButtonModule } from '@angular/material/button';
+import { FairService, Fair } from './fair.service';
+import { AttractionService, Attraction } from './attraction.service';
+
+@Component({
+  selector: 'app-fair-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule],
+  templateUrl: './fair-detail.component.html',
+  styleUrls: ['./fair-detail.component.scss']
+})
+export class FairDetailComponent implements OnInit {
+  fair?: Fair;
+  attractions: Attraction[] = [];
+
+  constructor(
+    private route: ActivatedRoute,
+    private fairService: FairService,
+    private attractionService: AttractionService
+  ) {}
+
+  ngOnInit() {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (id) {
+      this.fairService.get(id).subscribe(f => (this.fair = f));
+      this.attractionService.listByFair(id).subscribe(list => (this.attractions = list));
+    }
+  }
+}

--- a/front/src/app/fair/fair-popup.component.html
+++ b/front/src/app/fair/fair-popup.component.html
@@ -7,5 +7,8 @@
     <div class="info-item" *ngIf="fair.responsible"><span class="label">{{ 'FAIR.RESPONSIBLE' | translate }}:</span> {{ fair.responsible }}</div>
     <div class="info-item" *ngIf="fair.phone"><span class="label">{{ 'FAIR.PHONE' | translate }}:</span> {{ fair.phone }}</div>
     <div class="info-item" *ngIf="fair.description"><span class="label">{{ 'FAIR.DESCRIPTION' | translate }}:</span> {{ fair.description }}</div>
+    <button mat-button color="primary" [routerLink]="['/fair', fair.id]" class="detail-btn">
+      {{ 'FAIR.DETAILS' | translate }}
+    </button>
   </div>
 </div>

--- a/front/src/app/fair/fair-popup.component.scss
+++ b/front/src/app/fair/fair-popup.component.scss
@@ -13,3 +13,9 @@
   object-fit: contain;
   margin-bottom: 8px;
 }
+
+.detail-btn {
+  margin-top: 8px;
+  padding: 0;
+  min-width: 0;
+}

--- a/front/src/app/fair/fair-popup.component.ts
+++ b/front/src/app/fair/fair-popup.component.ts
@@ -1,11 +1,14 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule } from '@ngx-translate/core';
 import { Fair } from './fair.service';
 
 @Component({
   selector: 'app-fair-popup',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule],
   templateUrl: './fair-popup.component.html',
   styleUrls: ['./fair-popup.component.scss']
 })

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -104,7 +104,8 @@
       "RESPONSIBLE": "Responsible",
       "PHONE": "Phone",
       "IMAGE": "Image",
-      "SAVE": "Save"
+      "SAVE": "Save",
+      "DETAILS": "View details >"
       },
       "MANAGE_FAIRS": "Manage fairs",
       "NO_FAIRS": "No fairs found",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -111,7 +111,8 @@
       "ACTIONS": "Ações",
       "EDIT": "Editar",
       "REMOVE": "Remover",
-      "SAVE": "Salvar"
+      "SAVE": "Salvar",
+      "DETAILS": "Ver detalhes >"
     },
     "MANAGE_FAIRS": "Gerenciar feiras",
     "NO_FAIRS": "Nenhuma feira cadastrada",


### PR DESCRIPTION
## Summary
- add Attraction entity and controller
- expose repository for Attraction
- include Fair detail route and component
- allow translating in fair popup and provide detail button
- add translation key for details

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695bcc46f88329bd3155663bce945c