### PR TITLE
Fix lazy initialization error on Fair JSON serialization

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
@@ -36,7 +36,7 @@ public class Fair {
     private String phone;
     private String imagePath;
 
-    @OneToMany(mappedBy = "fair", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "fair", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<Attraction> attractionList;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## Summary
- ensure attractions are fetched when listing a Fair

## Testing
- `mvnw -q -DskipTests package` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68695eb01ee48329bc7a92a936426661