### PR TITLE
Fix fair management and attractions editing

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -20,7 +20,7 @@ export const routes: Routes = [
   { path: 'fair', component: FairMapComponent },
   { path: 'fair/new', component: FairFormComponent, canActivate: [AuthGuard] },
   { path: 'fair/:id/edit', component: FairFormComponent, canActivate: [AuthGuard] },
-  { path: 'fair/:id', component: FairDetailComponent },
   { path: 'fair/manage', component: FairListComponent, canActivate: [AuthGuard] },
+  { path: 'fair/:id', component: FairDetailComponent },
   { path: '**', redirectTo: 'login' }
 ];

--- a/front/src/app/fair/fair-form.component.html
+++ b/front/src/app/fair/fair-form.component.html
@@ -37,10 +37,41 @@
         <mat-label>Redes sociais</mat-label>
         <input matInput formControlName="socialMedia" />
       </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Atrações</mat-label>
-        <textarea matInput formControlName="attractions"></textarea>
-      </mat-form-field>
+      <div class="attraction-section">
+        <h3>Atrações</h3>
+        <table mat-table [dataSource]="attractions" class="attraction-table" *ngIf="attractions.length">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Nome</th>
+            <td mat-cell *matCellDef="let a; let i = index">
+              <input matInput [(ngModel)]="a.name" name="name{{i}}" />
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="specialty">
+            <th mat-header-cell *matHeaderCellDef>Especialidade</th>
+            <td mat-cell *matCellDef="let a; let i = index">
+              <input matInput [(ngModel)]="a.specialty" name="spec{{i}}" />
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="socialMedia">
+            <th mat-header-cell *matHeaderCellDef>Rede social</th>
+            <td mat-cell *matCellDef="let a; let i = index">
+              <input matInput [(ngModel)]="a.socialMedia" name="soc{{i}}" />
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let a; let i = index">
+              <button mat-icon-button type="button" (click)="removeAttraction(i)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="['name','specialty','socialMedia','actions']"></tr>
+          <tr mat-row *matRowDef="let row; columns: ['name','specialty','socialMedia','actions'];"></tr>
+        </table>
+        <p *ngIf="!attractions.length">Nenhuma atração</p>
+        <button mat-button type="button" (click)="addAttraction()">Adicionar atração</button>
+      </div>
       <label class="images-label">Imagem</label>
       <input type="file" accept="image/*" (change)="onFile($event)" />
       <img *ngIf="imageUrl" [src]="imageUrl" class="preview-img" />

--- a/front/src/app/fair/fair-form.component.scss
+++ b/front/src/app/fair/fair-form.component.scss
@@ -42,3 +42,12 @@
   max-width: 200px;
   margin-top: 10px;
 }
+
+.attraction-section {
+  margin-top: 10px;
+}
+
+.attraction-table {
+  width: 100%;
+  margin-bottom: 8px;
+}

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -66,7 +66,7 @@ export class FairMapComponent implements OnInit {
           });
           compRef.instance.fair = f;
           popupHost.appendChild(compRef.location.nativeElement);
-          marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 260 }).openPopup();
+          marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 300 }).openPopup();
         });
         marker.on('popupclose', () => {
           if (compRef) {

--- a/front/src/app/fair/fair-popup.component.scss
+++ b/front/src/app/fair/fair-popup.component.scss
@@ -1,16 +1,30 @@
+:host ::ng-deep .leaflet-popup-content {
+  margin: 0;
+}
+
 .popup-card {
   font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  width: 260px;
 }
 
 .label {
   font-weight: bold;
 }
 
+.popup-info-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .popup-image {
   width: 100%;
   height: auto;
   max-height: 200px;
-  object-fit: contain;
+  object-fit: cover;
+  border-radius: 4px;
   margin-bottom: 8px;
 }
 
@@ -18,4 +32,5 @@
   margin-top: 8px;
   padding: 0;
   min-width: 0;
+  align-self: flex-start;
 }


### PR DESCRIPTION
## Summary
- fix route order so manage fairs page loads correctly
- improve popup card layout on map markers
- enlarge popup width
- allow editing attractions in fairs with a table
- style the attraction table in fair form

## Testing
- `npx ng test --watch=false` *(fails: ERROR [karma-server]: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_686961f48d0c8329b287e2fd396b1c98