### PR TITLE
Add day of week field and map filter

### DIFF
--- a/front/src/app/fair/fair-form.component.html
+++ b/front/src/app/fair/fair-form.component.html
@@ -5,6 +5,7 @@
   <button mat-icon-button type="button" class="close-btn" (click)="close()" *ngIf="dialogRef">
     <mat-icon>close</mat-icon>
   </button>
+  <button mat-button type="button" routerLink="/fair" class="back-btn" *ngIf="!dialogRef">&lt; {{ 'BACK_TO_MAP' | translate }}</button>
   <div class="form-columns">
     <div class="column">
       <mat-form-field appearance="outline" class="full-width">
@@ -24,8 +25,10 @@
         <input matInput formControlName="phone" mask="(00) 00000-0000" />
       </mat-form-field>
       <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Horário</mat-label>
-        <input matInput formControlName="schedule" />
+        <mat-label>Dia da semana</mat-label>
+        <mat-select formControlName="schedule">
+          <mat-option *ngFor="let d of daysOfWeek" [value]="d">{{ d }}</mat-option>
+        </mat-select>
       </mat-form-field>
     </div>
     <div class="column">

--- a/front/src/app/fair/fair-form.component.scss
+++ b/front/src/app/fair/fair-form.component.scss
@@ -3,6 +3,10 @@
   padding: 20px;
 }
 
+.back-btn {
+  margin-bottom: 10px;
+}
+
 .loading-overlay {
   position: absolute;
   top: 0;

--- a/front/src/app/fair/fair-form.component.ts
+++ b/front/src/app/fair/fair-form.component.ts
@@ -7,6 +7,7 @@ import { FairService, Fair } from './fair.service';
 import * as L from 'leaflet';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -26,6 +27,7 @@ import { forkJoin } from 'rxjs';
     RouterModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule,
     MatButtonModule,
     MatIconModule,
     MatProgressSpinnerModule,
@@ -45,6 +47,15 @@ export class FairFormComponent implements OnInit {
   imageUrl?: string;
   id?: number;
   attractions: Attraction[] = [];
+  daysOfWeek = [
+    'Domingo',
+    'Segunda',
+    'Terça',
+    'Quarta',
+    'Quinta',
+    'Sexta',
+    'Sábado'
+  ];
 
   constructor(
     private fb: FormBuilder,

--- a/front/src/app/fair/fair-list.component.html
+++ b/front/src/app/fair/fair-list.component.html
@@ -1,4 +1,5 @@
 <div class="fair-list">
+  <button mat-button routerLink="/fair" class="back-btn">&lt; {{ 'BACK_TO_MAP' | translate }}</button>
   <div class="actions">
     <mat-form-field appearance="outline">
       <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>

--- a/front/src/app/fair/fair-list.component.scss
+++ b/front/src/app/fair/fair-list.component.scss
@@ -8,3 +8,7 @@
   gap: 1rem;
   margin-bottom: 1rem;
 }
+
+.back-btn {
+  margin-bottom: 0.5rem;
+}

--- a/front/src/app/fair/fair-map.component.html
+++ b/front/src/app/fair/fair-map.component.html
@@ -1,3 +1,11 @@
+<div class="map-filter">
+  <mat-form-field appearance="outline">
+    <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>
+    <mat-select [(ngModel)]="day" (selectionChange)="applyFilter()">
+      <mat-option *ngFor="let d of daysOfWeek" [value]="d.value">{{ d.label }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+</div>
 <div id="map" class="map"></div>
 <button mat-fab color="primary" class="add-btn" (click)="addFair()" *ngIf="loggedIn">
   +

--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -7,3 +7,14 @@
   bottom: 20px;
   right: 20px;
 }
+
+.map-filter {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 400;
+  background: #fff;
+  padding: 4px;
+  border-radius: 4px;
+}

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -110,6 +110,7 @@
       "MANAGE_FAIRS": "Manage fairs",
       "NO_FAIRS": "No fairs found",
       "FILTER_DAY": "Filter by day",
+      "BACK_TO_MAP": "Back to map",
       "FOOTER": {
         "BY": "by jpfurlan"
       },

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -117,6 +117,7 @@
     "MANAGE_FAIRS": "Gerenciar feiras",
     "NO_FAIRS": "Nenhuma feira cadastrada",
     "FILTER_DAY": "Filtrar por dia",
+    "BACK_TO_MAP": "Voltar para o mapa",
     "FOOTER": {
       "BY": "by jpfurlan"
     },


### PR DESCRIPTION
## Summary
- add translations for `BACK_TO_MAP`
- add day selection and back button on fair form
- allow filtering fairs on the map by day of week
- overlay day filter on map page
- add back button on manage fairs page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869666a33d083299adc73e48d766f33