### PR TITLE
Improve map filter and details UI

### DIFF
--- a/front/src/app/fair/fair-detail.component.html
+++ b/front/src/app/fair/fair-detail.component.html
@@ -1,25 +1,41 @@
 <div class="fair-detail" *ngIf="fair">
-  <button mat-button routerLink="/fair">&lt; {{ 'COMMON.CLOSE' | translate }}</button>
-  <h2>{{ fair.name }}</h2>
-  <img *ngIf="fair.imagePath" [src]="fair.imagePath" class="detail-image" />
-  <div class="detail-info">
-    <div *ngIf="fair.address"><strong>{{ 'FAIR.ADDRESS' | translate }}:</strong> {{ fair.address }}</div>
-    <div *ngIf="fair.schedule"><strong>{{ 'FAIR.SCHEDULE' | translate }}:</strong> {{ fair.schedule }}</div>
-    <div *ngIf="fair.socialMedia">
-      <strong>{{ 'FAIR.SOCIAL_MEDIA' | translate }}:</strong>
-      <a [href]="fair.socialMedia" target="_blank">{{ fair.socialMedia }}</a>
+  <button mat-raised-button color="primary" routerLink="/fair" class="close-btn">
+    {{ 'COMMON.CLOSE' | translate }}
+  </button>
+  <mat-card class="fair-card">
+    <h2>{{ fair.name }}</h2>
+    <img *ngIf="fair.imagePath" [src]="fair.imagePath" class="detail-image" />
+    <div class="detail-info">
+      <div *ngIf="fair.address"><strong>{{ 'FAIR.ADDRESS' | translate }}:</strong> {{ fair.address }}</div>
+      <div *ngIf="fair.schedule"><strong>{{ 'FAIR.SCHEDULE' | translate }}:</strong> {{ fair.schedule }}</div>
+      <div *ngIf="fair.socialMedia">
+        <strong>{{ 'FAIR.SOCIAL_MEDIA' | translate }}:</strong>
+        <a [href]="fair.socialMedia" target="_blank">{{ fair.socialMedia }}</a>
+      </div>
+      <div *ngIf="fair.responsible"><strong>{{ 'FAIR.RESPONSIBLE' | translate }}:</strong> {{ fair.responsible }}</div>
+      <div *ngIf="fair.phone"><strong>{{ 'FAIR.PHONE' | translate }}:</strong> {{ fair.phone }}</div>
+      <div *ngIf="fair.description"><strong>{{ 'FAIR.DESCRIPTION' | translate }}:</strong> {{ fair.description }}</div>
     </div>
-    <div *ngIf="fair.responsible"><strong>{{ 'FAIR.RESPONSIBLE' | translate }}:</strong> {{ fair.responsible }}</div>
-    <div *ngIf="fair.phone"><strong>{{ 'FAIR.PHONE' | translate }}:</strong> {{ fair.phone }}</div>
-    <div *ngIf="fair.description"><strong>{{ 'FAIR.DESCRIPTION' | translate }}:</strong> {{ fair.description }}</div>
-  </div>
-  <div class="attractions" *ngIf="attractions.length">
-    <h3>{{ 'FAIR.ATTRACTIONS' | translate }}</h3>
-    <ul>
-      <li *ngFor="let a of attractions">
-        {{ a.name }} - {{ a.specialty }}
-        <a *ngIf="a.socialMedia" [href]="a.socialMedia" target="_blank">{{ a.socialMedia }}</a>
-      </li>
-    </ul>
-  </div>
+    <div class="attractions" *ngIf="attractions.length">
+      <h3>{{ 'FAIR.ATTRACTIONS' | translate }}</h3>
+      <table class="attractions-table">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Especialidade</th>
+            <th>Rede social</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let a of attractions">
+            <td>{{ a.name }}</td>
+            <td>{{ a.specialty }}</td>
+            <td>
+              <a *ngIf="a.socialMedia" [href]="a.socialMedia" target="_blank">{{ a.socialMedia }}</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </mat-card>
 </div>

--- a/front/src/app/fair/fair-detail.component.scss
+++ b/front/src/app/fair/fair-detail.component.scss
@@ -1,8 +1,41 @@
 .fair-detail {
   padding: 16px;
 }
+
+.close-btn {
+  margin-bottom: 16px;
+}
+
+.fair-card {
+  padding: 16px;
+}
+
 .detail-image {
   width: 100%;
   max-width: 400px;
   margin: 16px 0;
+}
+
+.detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attractions {
+  margin-top: 16px;
+}
+
+.attractions-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.attractions-table th,
+.attractions-table td {
+  padding: 4px 8px;
+}
+
+.attractions-table th {
+  text-align: left;
 }

--- a/front/src/app/fair/fair-detail.component.ts
+++ b/front/src/app/fair/fair-detail.component.ts
@@ -3,13 +3,14 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { FairService, Fair } from './fair.service';
 import { AttractionService, Attraction } from './attraction.service';
 
 @Component({
   selector: 'app-fair-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, MatCardModule, TranslateModule],
   templateUrl: './fair-detail.component.html',
   styleUrls: ['./fair-detail.component.scss']
 })

--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -11,8 +11,7 @@
 .map-filter {
   position: absolute;
   top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 10px;
   z-index: 400;
   background: #fff;
   padding: 4px;


### PR DESCRIPTION
## Summary
- move map filter to the upper left corner of the map
- show fair details in a card with more spacing
- list attractions as a table
- add a raised button for closing the details view

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696e646e388329a2f5726ff359c010