### PR TITLE
Fix map filter position

### DIFF
--- a/front/src/app/fair/fair-map.component.html
+++ b/front/src/app/fair/fair-map.component.html
@@ -1,12 +1,14 @@
-<div class="map-filter">
-  <mat-form-field appearance="outline">
-    <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>
-    <mat-select [(ngModel)]="day" (selectionChange)="applyFilter()">
-      <mat-option *ngFor="let d of daysOfWeek" [value]="d.value">{{ d.label }}</mat-option>
-    </mat-select>
-  </mat-form-field>
+<div class="map-container">
+  <div id="map" class="map"></div>
+  <div class="map-filter">
+    <mat-form-field appearance="outline">
+      <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>
+      <mat-select [(ngModel)]="day" (selectionChange)="applyFilter()">
+        <mat-option *ngFor="let d of daysOfWeek" [value]="d.value">{{ d.label }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
 </div>
-<div id="map" class="map"></div>
 <button mat-fab color="primary" class="add-btn" (click)="addFair()" *ngIf="loggedIn">
   +
 </button>

--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -1,3 +1,8 @@
+
+.map-container {
+  position: relative;
+}
+
 .map {
   height: calc(100vh - 64px);
 }
@@ -11,7 +16,7 @@
 .map-filter {
   position: absolute;
   top: 10px;
-  left: 10px;
+  right: 10px;
   z-index: 400;
   background: #fff;
   padding: 4px;

--- a/front/src/app/fair/fair-popup.component.html
+++ b/front/src/app/fair/fair-popup.component.html
@@ -7,6 +7,7 @@
     <div class="info-item" *ngIf="fair.responsible"><span class="label">{{ 'FAIR.RESPONSIBLE' | translate }}:</span> {{ fair.responsible }}</div>
     <div class="info-item" *ngIf="fair.phone"><span class="label">{{ 'FAIR.PHONE' | translate }}:</span> {{ fair.phone }}</div>
     <div class="info-item" *ngIf="fair.description"><span class="label">{{ 'FAIR.DESCRIPTION' | translate }}:</span> {{ fair.description }}</div>
+    <div class="info-item" *ngIf="fair.attractions"><span class="label">{{ 'FAIR.ATTRACTIONS' | translate }}:</span> {{ fair.attractions }}</div>
     <button mat-button color="primary" [routerLink]="['/fair', fair.id]" class="detail-btn">
       {{ 'FAIR.DETAILS' | translate }}
     </button>


### PR DESCRIPTION
## Summary
- move map filter container inside the map
- adjust map styles for relative positioning
- show attractions in fair popup

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686972d7a93083298613d8469ebcedbe