### PR TITLE
Fix map icons without binary files

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -66,7 +66,7 @@ public class SecurityConfiguration {
                   .csrf(AbstractHttpConfigurer::disable)
                   .authorizeHttpRequests(auth -> auth
                           .requestMatchers(mvc.pattern("/api/v1/auth/**")).permitAll()
-                          .requestMatchers(HttpMethod.GET, "/api/v1/fair/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/fairs/**").permitAll()
                           .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                           .requestMatchers(SWAGGER_WHITELIST).permitAll()
                           .anyRequest().authenticated())

--- a/front/angular.json
+++ b/front/angular.json
@@ -27,10 +27,15 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               {
-                "glob": "**/*",
-                "input": "public"
-              },
-              "src/assets"
+              "glob": "**/*",
+              "input": "public"
+            },
+              "src/assets",
+              {
+                "glob": "*.*",
+                "input": "./node_modules/leaflet/dist/images",
+                "output": "assets/leaflet"
+              }
             ],
             "stylePreprocessorOptions": {
               "includePaths": [
@@ -96,7 +101,12 @@
                 "glob": "**/*",
                 "input": "public"
               },
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "*.*",
+                "input": "./node_modules/leaflet/dist/images",
+                "output": "assets/leaflet"
+              }
             ],
             "stylePreprocessorOptions": {
               "includePaths": [

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -1,6 +1,12 @@
 import { Component, OnInit, ViewContainerRef, EnvironmentInjector } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import * as L from 'leaflet';
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'assets/leaflet/marker-icon-2x.png',
+  iconUrl: 'assets/leaflet/marker-icon.png',
+  shadowUrl: 'assets/leaflet/marker-shadow.png'
+});
 import { FairService, Fair } from './fair.service';
 import { RouterModule, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -89,13 +95,15 @@ export class FairMapComponent implements OnInit {
           if (compRef) {
             compRef.destroy();
           }
+          marker.unbindPopup();
           const popupHost = document.createElement('div');
           compRef = this.vcr.createComponent(FairPopupComponent, {
             environmentInjector: this.injector
           });
           compRef.instance.fair = f;
           popupHost.appendChild(compRef.location.nativeElement);
-          marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 300 }).openPopup();
+          marker.bindPopup(popupHost, { className: 'fair-popup', maxWidth: 300 });
+          marker.openPopup();
         });
         marker.on('popupclose', () => {
           if (compRef) {

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -105,7 +105,7 @@
       "PHONE": "Phone",
       "IMAGE": "Image",
       "SAVE": "Save",
-      "DETAILS": "View details >"
+      "DETAILS": "View details"
       },
       "MANAGE_FAIRS": "Manage fairs",
       "NO_FAIRS": "No fairs found",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -112,7 +112,7 @@
       "EDIT": "Editar",
       "REMOVE": "Remover",
       "SAVE": "Salvar",
-      "DETAILS": "Ver detalhes >"
+      "DETAILS": "Ver detalhes"
     },
     "MANAGE_FAIRS": "Gerenciar feiras",
     "NO_FAIRS": "Nenhuma feira cadastrada",


### PR DESCRIPTION
## Summary
- allow anonymous GET access to `/api/v1/fairs/**`
- configure Leaflet icons to load from bundled assets
- copy Leaflet images from `node_modules` during build and drop local copies
- ensure marker popups reopen properly
- adjust translation text for "View details"

## Testing
- `npx ng test --watch=false` *(failed: could not determine executable to run)*
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c16362448329b0adcb7e7fe4b8a6