### PR TITLE
Fix fairs endpoint auth

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -66,7 +66,7 @@ public class SecurityConfiguration {
                   .csrf(AbstractHttpConfigurer::disable)
                   .authorizeHttpRequests(auth -> auth
                           .requestMatchers(mvc.pattern("/api/v1/auth/**")).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/fairs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/fairs", "/api/v1/fairs/**").permitAll()
                           .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                           .requestMatchers(SWAGGER_WHITELIST).permitAll()
                           .anyRequest().authenticated())


### PR DESCRIPTION
## Summary
- allow public GET access to `/fairs` without authentication

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_686a4fb118dc8329a7c85cff201aec11