### PR TITLE
Add opening hours field

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/fair/Fair.java
@@ -30,6 +30,7 @@ public class Fair {
     private String address;
     private String description;
     private String schedule;
+    private String openingHours;
     private String socialMedia;
     private String attractions;
     private String responsible;

--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/fair/FairService.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/fair/FairService.java
@@ -52,6 +52,7 @@ public class FairService {
         existing.setAddress(data.getAddress());
         existing.setDescription(data.getDescription());
         existing.setSchedule(data.getSchedule());
+        existing.setOpeningHours(data.getOpeningHours());
         existing.setSocialMedia(data.getSocialMedia());
         existing.setAttractions(data.getAttractions());
         existing.setResponsible(data.getResponsible());

--- a/front/src/app/fair/fair-detail.component.html
+++ b/front/src/app/fair/fair-detail.component.html
@@ -8,6 +8,7 @@
     <div class="detail-info">
       <div *ngIf="fair.address"><strong>{{ 'FAIR.ADDRESS' | translate }}:</strong> {{ fair.address }}</div>
       <div *ngIf="fair.schedule"><strong>{{ 'FAIR.SCHEDULE' | translate }}:</strong> {{ fair.schedule }}</div>
+      <div *ngIf="fair.openingHours"><strong>{{ 'FAIR.OPENING_HOURS' | translate }}:</strong> {{ fair.openingHours }}</div>
       <div *ngIf="fair.socialMedia">
         <strong>{{ 'FAIR.SOCIAL_MEDIA' | translate }}:</strong>
         <a [href]="fair.socialMedia" target="_blank">{{ fair.socialMedia }}</a>

--- a/front/src/app/fair/fair-form.component.html
+++ b/front/src/app/fair/fair-form.component.html
@@ -25,6 +25,10 @@
         <input matInput formControlName="phone" mask="(00) 00000-0000" />
       </mat-form-field>
       <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Horário de funcionamento</mat-label>
+        <input matInput formControlName="openingHours" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
         <mat-label>Dia da semana</mat-label>
         <mat-select formControlName="schedule">
           <mat-option *ngFor="let d of daysOfWeek" [value]="d">{{ d }}</mat-option>

--- a/front/src/app/fair/fair-form.component.ts
+++ b/front/src/app/fair/fair-form.component.ts
@@ -5,6 +5,12 @@ import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FairService, Fair } from './fair.service';
 import * as L from 'leaflet';
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'assets/leaflet/marker-icon-2x.png',
+  iconUrl: 'assets/leaflet/marker-icon.png',
+  shadowUrl: 'assets/leaflet/marker-shadow.png'
+});
+L.Icon.Default.imagePath = 'assets/leaflet/';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -71,6 +77,7 @@ export class FairFormComponent implements OnInit {
       address: [''],
       description: [''],
       schedule: [''],
+      openingHours: [''],
       socialMedia: [''],
       responsible: [''],
       phone: [''],

--- a/front/src/app/fair/fair-list.component.html
+++ b/front/src/app/fair/fair-list.component.html
@@ -31,6 +31,10 @@
       <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.SCHEDULE' | translate }}</th>
       <td mat-cell *matCellDef="let f">{{ f.schedule }}</td>
     </ng-container>
+    <ng-container matColumnDef="openingHours">
+      <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.OPENING_HOURS' | translate }}</th>
+      <td mat-cell *matCellDef="let f">{{ f.openingHours }}</td>
+    </ng-container>
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>{{ 'FAIR.ACTIONS' | translate }}</th>
       <td mat-cell *matCellDef="let f">
@@ -43,8 +47,8 @@
       </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="['name','responsible','phone','schedule','actions']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['name','responsible','phone','schedule','actions'];"></tr>
+    <tr mat-header-row *matHeaderRowDef="['name','responsible','phone','schedule','openingHours','actions']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['name','responsible','phone','schedule','openingHours','actions'];"></tr>
   </table>
 
   <p *ngIf="!filtered.length">{{ 'NO_FAIRS' | translate }}</p>

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -7,6 +7,7 @@ L.Icon.Default.mergeOptions({
   iconUrl: 'assets/leaflet/marker-icon.png',
   shadowUrl: 'assets/leaflet/marker-shadow.png'
 });
+L.Icon.Default.imagePath = 'assets/leaflet/';
 import { FairService, Fair } from './fair.service';
 import { RouterModule, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';

--- a/front/src/app/fair/fair-popup.component.html
+++ b/front/src/app/fair/fair-popup.component.html
@@ -3,8 +3,9 @@
   <div class="popup-info-card">
     <div class="info-item"><span class="label">{{ 'FAIR.NAME' | translate }}:</span> {{ fair.name }}</div>
     <div class="info-item" *ngIf="fair.address"><span class="label">{{ 'FAIR.ADDRESS' | translate }}:</span> {{ fair.address }}</div>
-    <div class="info-item" *ngIf="fair.schedule"><span class="label">{{ 'FAIR.SCHEDULE' | translate }}:</span> {{ fair.schedule }}</div>
-    <div class="info-item" *ngIf="fair.responsible"><span class="label">{{ 'FAIR.RESPONSIBLE' | translate }}:</span> {{ fair.responsible }}</div>
+  <div class="info-item" *ngIf="fair.schedule"><span class="label">{{ 'FAIR.SCHEDULE' | translate }}:</span> {{ fair.schedule }}</div>
+  <div class="info-item" *ngIf="fair.openingHours"><span class="label">{{ 'FAIR.OPENING_HOURS' | translate }}:</span> {{ fair.openingHours }}</div>
+  <div class="info-item" *ngIf="fair.responsible"><span class="label">{{ 'FAIR.RESPONSIBLE' | translate }}:</span> {{ fair.responsible }}</div>
     <div class="info-item" *ngIf="fair.phone"><span class="label">{{ 'FAIR.PHONE' | translate }}:</span> {{ fair.phone }}</div>
     <div class="info-item" *ngIf="fair.description"><span class="label">{{ 'FAIR.DESCRIPTION' | translate }}:</span> {{ fair.description }}</div>
     <div class="info-item" *ngIf="fair.attractions"><span class="label">{{ 'FAIR.ATTRACTIONS' | translate }}:</span> {{ fair.attractions }}</div>

--- a/front/src/app/fair/fair.service.ts
+++ b/front/src/app/fair/fair.service.ts
@@ -11,6 +11,7 @@ export interface Fair {
   address?: string;
   description?: string;
   schedule?: string;
+  openingHours?: string;
   socialMedia?: string;
   attractions?: string;
   responsible?: string;

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -95,6 +95,7 @@
         "ADDRESS": "Address",
         "DESCRIPTION": "Description",
         "SCHEDULE": "Schedule",
+        "OPENING_HOURS": "Opening hours",
         "SOCIAL_MEDIA": "Social media",
         "ATTRACTIONS": "Attractions",
         "SELECT_LOCATION": "Select location",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -102,6 +102,7 @@
       "ADDRESS": "Endereço",
       "DESCRIPTION": "Descrição",
       "SCHEDULE": "Horário",
+      "OPENING_HOURS": "Horário de funcionamento",
       "SOCIAL_MEDIA": "Redes sociais",
       "ATTRACTIONS": "Atrações",
       "RESPONSIBLE": "Responsável",


### PR DESCRIPTION
## Summary
- add openingHours field on Fair entity and service
- update Angular service, forms, and UI to edit and display opening hours
- update translations
- ensure leaflet assets path set for map icons

## Testing
- `mvn -q test` *(fails: mvn command not found initially, installed maven, tests ran with no output)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a7ed0ea30832995265bc092dcb00e