### PR TITLE
Fix Leaflet icon path

### DIFF
--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -7,7 +7,6 @@ L.Icon.Default.mergeOptions({
   iconUrl: 'assets/leaflet/marker-icon.png',
   shadowUrl: 'assets/leaflet/marker-shadow.png'
 });
-L.Icon.Default.imagePath = 'assets/leaflet/';
 import { FairService, Fair } from './fair.service';
 import { RouterModule, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';


### PR DESCRIPTION
## Summary
- fix Leaflet marker icon path so images load correctly

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_686a85fdc1e083299f7df120605db597