### PR TITLE
Fix attractions not loading

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -67,7 +67,8 @@ public class SecurityConfiguration {
                   .authorizeHttpRequests(auth -> auth
                           .requestMatchers(mvc.pattern("/api/v1/auth/**")).permitAll()
                         .requestMatchers(mvc.pattern("/api/v1/fairs")).permitAll()
-                          .requestMatchers(mvc.pattern("/api/v1/fairs/**")).permitAll()
+                        .requestMatchers(mvc.pattern("/api/v1/fairs/**")).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/attractions/**").permitAll()
                           .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                           .requestMatchers(SWAGGER_WHITELIST).permitAll()
                           .anyRequest().authenticated())


### PR DESCRIPTION
## Summary
- allow anonymous GET requests for /api/v1/attractions

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c214475e88329a446f037e93a3c59