### PR TITLE
Add fair type filter

### DIFF
--- a/front/src/app/fair/fair-map.component.html
+++ b/front/src/app/fair/fair-map.component.html
@@ -7,5 +7,17 @@
         <mat-option *ngFor="let d of daysOfWeek" [value]="d.value">{{ d.label }}</mat-option>
       </mat-select>
     </mat-form-field>
+    <div class="type-filter">
+      <label>{{ 'FILTER_TYPE' | translate }}</label>
+      <mat-checkbox
+        *ngFor="let t of types"
+        [checked]="selectedTypes.includes(t)"
+        (change)="toggleType(t, $event.checked)"
+        [ngModelOptions]="{standalone: true}"
+      >
+        <img [src]="iconUrl(t)" class="type-icon" />
+        {{ ('FAIR.TYPE_' + t) | translate }}
+      </mat-checkbox>
+    </div>
   </div>
 </div>

--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -17,3 +17,20 @@
   padding: 4px;
   border-radius: 4px;
 }
+
+.type-filter {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+  .mat-checkbox {
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+  }
+}
+
+.type-icon {
+  width: 24px;
+  height: 24px;
+  margin: 0 4px;
+}

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -18,6 +18,7 @@ import { RouterModule, Router } from "@angular/router";
 import { MatButtonModule } from "@angular/material/button";
 import { MatSelectModule } from "@angular/material/select";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatCheckboxModule } from "@angular/material/checkbox";
 import { FormsModule } from "@angular/forms";
 import { TranslateModule } from "@ngx-translate/core";
 import { FairPopupComponent } from "./fair-popup.component";
@@ -31,6 +32,7 @@ import { FairPopupComponent } from "./fair-popup.component";
     FormsModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatCheckboxModule,
     MatButtonModule,
     TranslateModule,
     FairPopupComponent,
@@ -55,6 +57,9 @@ export class FairMapComponent implements OnInit {
     { value: "Sexta", label: "Sexta-feira" },
     { value: "Sábado", label: "Sábado" },
   ];
+
+  types = Object.values(FairType);
+  selectedTypes: FairType[] = [...this.types];
 
   constructor(
     private service: FairService,
@@ -86,6 +91,20 @@ export class FairMapComponent implements OnInit {
       popupAnchor: [0, -82],
       shadowUrl: 'assets/leaflet/marker-shadow.png',
     });
+  }
+
+  iconUrl(type: FairType): string {
+    switch (type) {
+      case FairType.FESTA_JUNINA:
+        return 'assets/leaflet/festajunina.png';
+      case FairType.PASTEL:
+        return 'assets/leaflet/pastel.png';
+      case FairType.FEIRA_DA_LUA:
+        return 'assets/leaflet/feiradalua.png';
+      case FairType.FEIRA_GENERICA:
+      default:
+        return 'assets/leaflet/feiragenerica.png';
+    }
   }
 
   get loggedIn(): boolean {
@@ -192,16 +211,25 @@ export class FairMapComponent implements OnInit {
   }
 
   applyFilter() {
-    if (!this.day) {
-      this.filtered = this.fairs;
-    } else {
-      const d = this.day.toLowerCase();
-      this.filtered = this.fairs.filter((f) =>
-        f.schedule?.toLowerCase().includes(d),
-      );
-    }
+    const d = this.day.toLowerCase();
+    this.filtered = this.fairs.filter((f) => {
+      const dayMatch = !this.day || f.schedule?.toLowerCase().includes(d);
+      const typeMatch = !f.type || this.selectedTypes.includes(f.type);
+      return dayMatch && typeMatch;
+    });
     this.buildCluster();
     this.updateClusters();
+  }
+
+  toggleType(type: FairType, checked: boolean) {
+    if (checked) {
+      if (!this.selectedTypes.includes(type)) {
+        this.selectedTypes.push(type);
+      }
+    } else {
+      this.selectedTypes = this.selectedTypes.filter((t) => t !== type);
+    }
+    this.applyFilter();
   }
 
   addFair() {

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -117,6 +117,7 @@
       "NO_FAIRS": "No fairs found",
       "NO_ATTRACTIONS": "No attractions",
       "FILTER_DAY": "Filter by day",
+      "FILTER_TYPE": "Filter by type",
       "BACK_TO_MAP": "Back to map",
       "CONTRIBUTE": {
         "TITLE": "Contribute",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -124,6 +124,7 @@
     "NO_FAIRS": "Nenhuma feira cadastrada",
     "NO_ATTRACTIONS": "Nenhuma atração",
     "FILTER_DAY": "Filtrar por dia",
+    "FILTER_TYPE": "Filtrar por tipo",
     "BACK_TO_MAP": "Voltar para o mapa",
     "CONTRIBUTE": {
       "TITLE": "Contribua",


### PR DESCRIPTION
## Summary
- add checkbox filter by fair type below day filter
- include fair type icons in map filter
- support filtering by fair type in map component
- provide translations for the new filter

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c607e81cc8329be312882cf2bbbfc