### PR TITLE
Fix ngModelOptions error

### DIFF
--- a/front/src/app/fair/fair-map.component.html
+++ b/front/src/app/fair/fair-map.component.html
@@ -13,7 +13,6 @@
         *ngFor="let t of types"
         [checked]="selectedTypes.includes(t)"
         (change)="toggleType(t, $event.checked)"
-        [ngModelOptions]="{standalone: true}"
       >
         <img [src]="iconUrl(t)" class="type-icon" />
         {{ ('FAIR.TYPE_' + t) | translate }}

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -35,7 +35,6 @@ import { FairPopupComponent } from "./fair-popup.component";
     MatCheckboxModule,
     MatButtonModule,
     TranslateModule,
-    FairPopupComponent,
   ],
   templateUrl: "./fair-map.component.html",
   styleUrls: ["./fair-map.component.scss"],


### PR DESCRIPTION
## Summary
- remove unused ngModelOptions on FairMapComponent
- remove FairPopupComponent from template imports

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_686c6c9d37908329a3d7a3d7057f0183