### PR TITLE
Add mobile filter toggle on map

### DIFF
--- a/front/src/app/fair/fair-map.component.html
+++ b/front/src/app/fair/fair-map.component.html
@@ -1,6 +1,17 @@
 <div class="map-container">
   <div id="map" class="map"></div>
-  <div class="map-filter">
+  <button
+    *ngIf="isMobile && !filtersVisible"
+    class="filter-toggle"
+    mat-fab
+    color="primary"
+    (click)="toggleFilters()">
+    <mat-icon>filter_list</mat-icon>
+  </button>
+  <div class="map-filter" *ngIf="!isMobile || filtersVisible">
+    <button *ngIf="isMobile" mat-icon-button class="close-filter" (click)="toggleFilters()">
+      <mat-icon>close</mat-icon>
+    </button>
     <mat-form-field appearance="outline">
       <mat-label>{{ 'FILTER_DAY' | translate }}</mat-label>
       <mat-select [(ngModel)]="day" (selectionChange)="applyFilter()">

--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -18,6 +18,17 @@
   border-radius: 4px;
 }
 
+.filter-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 400;
+}
+
+.close-filter {
+  float: right;
+}
+
 .type-filter {
   display: flex;
   flex-direction: column;

--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -20,6 +20,7 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { FormsModule } from "@angular/forms";
+import { MatIconModule } from "@angular/material/icon";
 import { TranslateModule } from "@ngx-translate/core";
 import { FairPopupComponent } from "./fair-popup.component";
 
@@ -34,6 +35,7 @@ import { FairPopupComponent } from "./fair-popup.component";
     MatSelectModule,
     MatCheckboxModule,
     MatButtonModule,
+    MatIconModule,
     TranslateModule,
   ],
   templateUrl: "./fair-map.component.html",
@@ -59,6 +61,8 @@ export class FairMapComponent implements OnInit {
 
   types = Object.values(FairType);
   selectedTypes: FairType[] = [...this.types];
+  isMobile = false;
+  filtersVisible = true;
 
   constructor(
     private service: FairService,
@@ -111,6 +115,8 @@ export class FairMapComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.isMobile = window.innerWidth <= 600;
+    this.filtersVisible = !this.isMobile;
     this.service.list().subscribe((fairs) => {
       this.fairs = fairs;
       this.filtered = fairs;
@@ -229,6 +235,10 @@ export class FairMapComponent implements OnInit {
       this.selectedTypes = this.selectedTypes.filter((t) => t !== type);
     }
     this.applyFilter();
+  }
+
+  toggleFilters() {
+    this.filtersVisible = !this.filtersVisible;
   }
 
   addFair() {


### PR DESCRIPTION
## Summary
- show filter toggle icon on mobile map
- open and close filters on mobile

## Testing
- `npm test --silent --unsafe-perm` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686c7081ec588329b2869db0b8bb3e60