### PR TITLE
Add compose setup for deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Domain where the frontend will be served
+FRONT_DOMAIN=feira.example.com
+# Domain where the backend API will be served
+BACK_DOMAIN=api.feira.example.com
+# Email used for Let's Encrypt notifications
+LETSENCRYPT_EMAIL=admin@example.com
+# Database password
+POSTGRES_PASSWORD=123456

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Feiras Londrina Deployment
+
+This project includes a Spring Boot backend and an Angular frontend. A `docker-compose.yml` file is provided to run the application together with a Postgres database. The services can be exposed through the [nginx-proxy](https://github.com/srcjp/proxy) stack which automatically manages SSL certificates with Let's Encrypt.
+
+## Prerequisites
+- Docker and Docker Compose
+- The proxy stack from [srcjp/proxy](https://github.com/srcjp/proxy) running on the same host
+
+## Usage
+1. Copy `.env.example` to `.env` and adjust the domain names, email address and database password.
+
+```bash
+cp .env.example .env
+# edit .env to match your environment
+```
+
+2. Build and start the containers:
+
+```bash
+docker-compose up -d --build
+```
+
+The backend will be available through the domain defined in `BACK_DOMAIN` and the frontend through `FRONT_DOMAIN`. SSL certificates are obtained automatically by the proxy stack.
+
+## Networks
+This compose file uses an external network named `proxy`. Ensure the proxy stack creates this network before starting the services:
+
+```bash
+docker network create proxy
+```
+
+Refer to the proxy repository for more details on configuring Nginx and Let's Encrypt.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: JwtRefresh
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - internal
+
+  backend:
+    build:
+      context: ./back
+    restart: unless-stopped
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/JwtRefresh
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+    depends_on:
+      - db
+    networks:
+      - internal
+      - proxy
+    expose:
+      - "8080"
+    labels:
+      - "com.github.nginx-proxy.nginx=nginx-proxy"
+      - "VIRTUAL_HOST=${BACK_DOMAIN}"
+      - "LETSENCRYPT_HOST=${BACK_DOMAIN}"
+      - "LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}"
+
+  frontend:
+    build:
+      context: ./front
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - internal
+      - proxy
+    expose:
+      - "80"
+    labels:
+      - "com.github.nginx-proxy.nginx=nginx-proxy"
+      - "VIRTUAL_HOST=${FRONT_DOMAIN}"
+      - "LETSENCRYPT_HOST=${FRONT_DOMAIN}"
+      - "LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}"
+
+networks:
+  internal:
+  proxy:
+    external: true
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add Docker Compose config to orchestrate backend, frontend and database
- add example environment file
- document how to deploy using docker and nginx-proxy

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c760d03fc83298dd942b94c1f13c3