### PR TITLE
Improve mobile popup handling

### DIFF
--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -199,6 +199,11 @@ export class FairMapComponent implements OnInit {
       } else {
         const fair = (c.properties as any).fair as Fair;
         const marker = L.marker([lat, lng], { icon: this.getIcon(fair.type) });
+        if (this.isMobile) {
+          marker.on('click', () => {
+            this.map?.setView([lat, lng], this.map.getZoom());
+          });
+        }
         marker.bindPopup("", { className: "fair-popup", maxWidth: 300 });
         marker.on("popupopen", () => {
           const popupHost = document.createElement("div");


### PR DESCRIPTION
## Summary
- when clicking a marker on mobile, pan the map to the marker before opening its popup

## Testing
- `npm test` *(fails: No binary for Chrome browser on platform)*

------
https://chatgpt.com/codex/tasks/task_e_686c7755e9848329be2cc77a64a61a90