### PR TITLE
Fix mobile popup recursion

### DIFF
--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -143,9 +143,10 @@ export class FairMapComponent implements OnInit {
         this.map.on("moveend zoomend", () => this.updateClusters());
         this.map.on("moveend", () => {
           if (this.pendingFairId !== undefined) {
-            const m = this.markerMap.get(this.pendingFairId);
-            m?.openPopup();
+            const id = this.pendingFairId;
             this.pendingFairId = undefined;
+            const m = this.markerMap.get(id);
+            m?.openPopup();
           }
         });
       },
@@ -161,9 +162,10 @@ export class FairMapComponent implements OnInit {
         this.map.on("moveend zoomend", () => this.updateClusters());
         this.map.on("moveend", () => {
           if (this.pendingFairId !== undefined) {
-            const m = this.markerMap.get(this.pendingFairId);
-            m?.openPopup();
+            const id = this.pendingFairId;
             this.pendingFairId = undefined;
+            const m = this.markerMap.get(id);
+            m?.openPopup();
           }
         });
       },


### PR DESCRIPTION
## Summary
- remove recursion when opening popups after map move

## Testing
- `npx -p @angular/cli ng test --watch=false` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_686d1f343d1883299d019c5b42e11f69