### PR TITLE
Disable auto-pan for fair popups

### DIFF
--- a/front/src/app/fair/fair-map.component.ts
+++ b/front/src/app/fair/fair-map.component.ts
@@ -225,7 +225,11 @@ export class FairMapComponent implements OnInit {
             this.map?.setView([lat, lng], this.map.getZoom());
           });
         }
-        marker.bindPopup("", { className: "fair-popup", maxWidth: 300 });
+        marker.bindPopup("", {
+          className: "fair-popup",
+          maxWidth: 300,
+          autoPan: false,
+        });
         marker.on("popupopen", () => {
           const popupHost = document.createElement("div");
           const compRef = this.vcr.createComponent(FairPopupComponent, {


### PR DESCRIPTION
## Summary
- fix popup error by turning off `autoPan`

## Testing
- `npx ng build --configuration development`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_686d21eacbbc8329a94fcc8aab7d9ce1