### PR TITLE
Reactivate attractions feature

### DIFF
--- a/front/src/app/fair/attraction.service.ts
+++ b/front/src/app/fair/attraction.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environmet/environment';
 
@@ -16,20 +16,25 @@ export class AttractionService {
 
   constructor(private http: HttpClient) {}
 
+  private get authOptions() {
+    const token = localStorage.getItem('accessToken');
+    return token ? { headers: new HttpHeaders({ Authorization: `Bearer ${token}` }) } : {};
+  }
+
   listByFair(fairId: number): Observable<Attraction[]> {
     return this.http.get<Attraction[]>(`${this.api}/fair/${fairId}`);
   }
 
   create(fairId: number, data: Attraction): Observable<Attraction> {
-    return this.http.post<Attraction>(`${this.api}/fair/${fairId}`, data);
+    return this.http.post<Attraction>(`${this.api}/fair/${fairId}`, data, this.authOptions);
   }
 
   update(id: number, data: Attraction): Observable<Attraction> {
-    return this.http.put<Attraction>(`${this.api}/${id}`, data);
+    return this.http.put<Attraction>(`${this.api}/${id}`, data, this.authOptions);
   }
 
   delete(id: number): Observable<void> {
-    return this.http.delete<void>(`${this.api}/${id}`);
+    return this.http.delete<void>(`${this.api}/${id}`, this.authOptions);
   }
 
   get(id: number): Observable<Attraction> {

--- a/front/src/app/fair/fair-detail.component.html
+++ b/front/src/app/fair/fair-detail.component.html
@@ -23,7 +23,7 @@
       </div>
     </div>
 
-    <!-- <div class="attractions" *ngIf="attractions.length; else noAttr">
+    <div class="attractions" *ngIf="attractions.length; else noAttr">
       <h3>{{ 'FAIR.ATTRACTIONS' | translate }}</h3>
       <table class="attractions-table">
         <thead>
@@ -47,12 +47,11 @@
 
     <ng-template #noAttr>
       <p>{{ 'NO_ATTRACTIONS' | translate }}</p>
-    </ng-template> -->
+    </ng-template>
 
     <!-- <div class="actions">
       <button mat-raised-button color="primary" [routerLink]="['/fair', fair.id, 'edit']">
         {{ 'EDIT' | translate }}
       </button>
     </div> -->
-  </mat-card>
-</div>
+  </mat-card></div>


### PR DESCRIPTION
## Summary
- show fair attractions on detail page
- authenticate attraction creation and updates

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb284964883298e42cc14456e2548