### PR TITLE
Fix editing fair loads attractions

### DIFF
--- a/front/src/app/fair/fair-form.component.ts
+++ b/front/src/app/fair/fair-form.component.ts
@@ -106,7 +106,9 @@ export class FairFormComponent implements OnInit {
         if (fair.imagePath) {
           this.imageUrl = fair.imagePath;
         }
-        this.attractions = attractions;
+        this.attractions = attractions.length
+          ? attractions
+          : fair.attractionList ?? [];
       });
     }
     this.initMap();

--- a/front/src/app/fair/fair.service.ts
+++ b/front/src/app/fair/fair.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from '../../environmet/environment';
 import { Observable, map } from 'rxjs';
+import { Attraction } from './attraction.service';
 
 export enum FairType {
   FESTA_JUNINA = 'FESTA_JUNINA',
@@ -26,6 +27,7 @@ export interface Fair {
   type?: FairType;
   imagePath?: string;
   createdAt?: string;
+  attractionList?: Attraction[];
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary
- expose attraction list in Fair interface
- populate attractions from the fair data when editing

## Testing
- `npm test` *(fails: ng not found)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb6b750688329bd00fe3aacad1c22