### PR TITLE
Fix fair form to load images and attractions

### DIFF
--- a/front/src/app/fair/fair-form.component.ts
+++ b/front/src/app/fair/fair-form.component.ts
@@ -100,15 +100,13 @@ export class FairFormComponent implements OnInit {
         attractions: this.attractionService.listByFair(this.id)
       }).subscribe(({ fair, attractions }) => {
         this.form.patchValue(fair);
-        if (fair.latitude && fair.longitude) {
-          this.setMarker([fair.latitude, fair.longitude]);
-        }
         if (fair.imagePath) {
           this.imageUrl = fair.imagePath;
         }
         this.attractions = attractions.length
           ? attractions
           : fair.attractionList ?? [];
+        this.setMarkerIfValid();
       });
     }
     this.initMap();
@@ -131,7 +129,11 @@ export class FairFormComponent implements OnInit {
   }
 
   private setMarkerIfValid() {
-    if (this.form.value.latitude && this.form.value.longitude) {
+    if (
+      this.map &&
+      this.form.value.latitude &&
+      this.form.value.longitude
+    ) {
       this.setMarker([this.form.value.latitude, this.form.value.longitude]);
     }
   }


### PR DESCRIPTION
## Summary
- handle case when map isn't initialized before data arrives
- avoid calling setMarker without a map

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686ec5c6dc4c83299ecdfad44c193369