### PR TITLE
Add version label and fix filter alignment

### DIFF
--- a/front/src/app/fair/fair-map.component.scss
+++ b/front/src/app/fair/fair-map.component.scss
@@ -42,7 +42,6 @@
 
 .type-icon {
   width: 18px;
-  height: 30px;
-  margin: 0 2px;
-  margin-top: 5px;
+  height: 18px;
+  margin-left: 4px;
 }

--- a/front/src/app/shared/header/header.component.html
+++ b/front/src/app/shared/header/header.component.html
@@ -1,5 +1,5 @@
 <header class="app-header">
-  <div (click)="gohome()" class="logo">Feiras Londrina</div>
+  <div (click)="gohome()" class="logo">Feiras Londrina<span class="version">v0.0.1</span></div>
 
   <div class="right-actions">
     <!-- <button mat-button (click)="openHowToUse()">{{ 'HOW_TO_USE.TITLE' | translate }}</button> -->
@@ -20,5 +20,4 @@
         </button>
       </mat-menu>
     </div>
-  </div>
-</header>
+  </div></header>

--- a/front/src/app/shared/header/header.component.scss
+++ b/front/src/app/shared/header/header.component.scss
@@ -11,6 +11,13 @@
   font-size: 1.5rem;
   font-weight: bold;
 }
+
+.version {
+  font-size: 12px;
+  font-weight: normal;
+  color: #000;
+  margin-left: 4px;
+}
 .lang-menu {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show version next to the header logo
- add style for version text
- tweak type filter icon size to align checkboxes

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ed3697f288329b4cd787c48b28ec5