### PR TITLE
Fix Angular build path and front nginx config

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -11,6 +11,7 @@ RUN sed -i "s@https://api.feiraslondrina.com.br@https://${BACK_DOMAIN}@" src/env
 
 # Runtime stage
 FROM nginx:stable-alpine
-COPY --from=build /app/dist/cadeopet /usr/share/nginx/html
+COPY --from=build /app/dist/cadeopet/browser /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Angular build output is correctly copied
- add nginx config in frontend image to support SPA routes

## Testing
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fdaf61448329859796379a699f08