### PR TITLE
Fix jar copy stage

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -28,13 +28,16 @@ RUN mvn clean package -DskipTests \
     -Dhttp.nonProxyHosts="*" \
     -Dhttps.nonProxyHosts="*"
 
+# Renomeia o JAR gerado para um nome padrao para facilitar a copia na etapa final
+RUN mv target/*.jar app.jar
+
 # Etapa final da imagem com JDK mais leve
 FROM openjdk:17.0.1-jdk-slim
 
 WORKDIR /app
 
 # Copia o JAR construído da etapa de build para a imagem final
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/app.jar app.jar
 
 # Expõe a porta que o aplicativo usará
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- rename built jar to `app.jar` in build stage
- copy renamed jar in final stage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687800a665508329884fed76a6f48a8f