### PR TITLE
Add Docker configuration for front, back and DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Feiras Londrina
+
+Este repositório contém o front-end em Angular e o back-end em Spring Boot de uma aplicação para gerenciamento de feiras em Londrina. Foram adicionados arquivos de Docker para facilitar a execução dos serviços em qualquer ambiente.
+
+## Requisitos
+- Docker
+- Docker Compose
+
+## Como executar
+1. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis se necessário.
+2. Execute o comando abaixo na raiz do projeto:
+   ```bash
+   docker compose up --build
+   ```
+3. O front ficará disponível em `http://localhost` e a API em `http://localhost:8080`.
+
+Os containers criados são:
+- **db**: instância PostgreSQL com volume persistente.
+- **back**: aplicação Spring Boot.
+- **front**: aplicação Angular servida pelo Nginx.
+
+Para parar os serviços utilize `docker compose down`.

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY . .
+RUN mvn -DskipTests package
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=cadeopet
 server.port=8080
-spring.datasource.url = jdbc:postgresql://localhost:5432/feiraslondrina
-spring.datasource.username = postgres
-spring.datasource.password = 123456
+spring.datasource.url=${DB_URL:jdbc:postgresql://db:5432/feiraslondrina}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:123456}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.database=postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: feiraslondrina
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-123456}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  back:
+    build: ./back
+    environment:
+      DB_URL: jdbc:postgresql://db:5432/feiraslondrina
+      DB_USERNAME: postgres
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-123456}
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  front:
+    build: ./front
+    ports:
+      - "80:80"
+    depends_on:
+      - back
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20 as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build -- --configuration production
+
+# Runtime stage
+FROM nginx:alpine
+COPY --from=build /app/dist/cadeopet /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add Dockerfile for Spring Boot backend
- add Dockerfile for Angular frontend
- configure docker-compose to run backend, frontend and PostgreSQL
- parametrize datasource properties for container usage
- provide basic project instructions in README

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dd50277c832990f423ab94802f3e